### PR TITLE
$KOTLIN_OPTS overrides //KOTLIN_OPTS in scriptlet.

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ The intial shebang could be left out by running the script directly with `kscrip
 println("Hello from Kotlin with 5g of heap memory running in server mode!")
 ```
 
+If environmental variable `KOTLIN_OPTS` is set, it will override the value set in the scriptlet.
 
 ### Scripts with a main method do not run with `kscript`?
 

--- a/kscript
+++ b/kscript
@@ -233,7 +233,11 @@ if [ -n "$dependencies" ] && [ -z "$classpath" ];then
 fi
 
 ## Extract kotlin arguments
-kotlin_opts=$(grep -F "//KOTLIN_OPTS" ${scriptFile} | head -n1 | cut -f2- -d' ')
+if [ -n "${KOTLIN_OPTS}" ];then
+  kotlin_opts=$KOTLIN_OPTS
+else
+  kotlin_opts="$(grep -F "//KOTLIN_OPTS" ${scriptFile} | head -n1 | cut -f2- -d' ')"
+fi
 
 
 ## Optionally enter interactive mode


### PR DESCRIPTION
I wanted to be able to change Kotlin opts (usually to add -J-agentlib:jdwp...) without changing the script, so I made $KOTLIN_OPTS in the environment override //KOTLIN_OPTS in the scriptlet.