### PR TITLE
Append $KSCRIPT_KOTLIN_OPTS to kotlin runtime opts.

### DIFF
--- a/src/main/kotlin/kscript/app/Kscript.kt
+++ b/src/main/kotlin/kscript/app/Kscript.kt
@@ -230,10 +230,16 @@ fun collectDependencies(scriptText: List<String>): List<String> {
 fun collectRuntimeOptions(scriptText: List<String>): String {
     val koptsPrefix = "//KOTLIN_OPTS "
 
+    // Append $KSCRIPT_KOTLIN_OPTS.
+    // Overriding //KOTLIN_OPTS lines in the script relies on the JVM processing
+    // arguments in order, which seems to be the case for Oracle, OpenJDK, and J9.
+    val kscriptOpts = System.getenv()["KSCRIPT_KOTLIN_OPTS"]
+
     return scriptText.
             filter { it.startsWith(koptsPrefix) }.
-            map { it.replace(koptsPrefix, "").trim() }.
-            joinToString(" ")
+            map { it.replaceFirst(koptsPrefix, "").trim() }.
+            joinToString(" ").
+            plus( if ( kscriptOpts.isNullOrBlank() ) "" else " ${kscriptOpts}" )
 }
 
 


### PR DESCRIPTION
A way to override //KOTLIN_OPTS lines in a script.

Supersedes #38.