### PR TITLE
Startup Time Improvement

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,15 +5,35 @@ apply plugin: 'java'
 apply plugin: 'kotlin'
 //apply plugin: 'maven'
 apply plugin: 'com.github.johnrengelman.shadow'
+apply plugin: 'application'
 
+sourceSets {
+    main.java.srcDirs += 'src/main/kotlin/'
+    test.java.srcDirs += 'src/test/kotlin/'
+}
+
+jar {
+    manifest {
+        attributes 'Main-Class': 'kscript.app.KscriptKt'
+    }
+    from {
+        configurations.compile.collect {
+            it.isDirectory() ? it : zipTree(it)
+        }
+    }
+}
+
+mainClassName = 'kscript.app.KscriptKt'
 
 dependencies {
 //    https://docs.gradle.org/current/userguide/java_plugin.html#sec:java_plugin_and_dependency_management
-    compileOnly "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-//    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+//    compileOnly "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-script-runtime:$kotlin_version"
 
 //    compile "org.apache.commons:commons-csv:1.3"
     compile "com.offbytwo:docopt:0.6.0.20150202"
+
 
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile "io.kotlintest:kotlintest:2.0.7"

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ repositories {
 }
 
 buildscript {
-    ext.kotlin_version = '1.1.4'
+    ext.kotlin_version = '1.2.10'
     repositories {
         jcenter()
     }

--- a/kscript
+++ b/kscript
@@ -53,4 +53,4 @@ while [ $# -gt 0 ]; do
 done
 
 ## run it
-KOTLIN_HOME=${kotlin_home} exec java $JAVA_OPTS "${java_args[@]}" -jar ${jarPath} "${kscript_args[@]}"
+KOTLIN_HOME=${kotlin_home} KSCRIPT_JAR=${jarPath} exec java $JAVA_OPTS "${java_args[@]}" -jar ${jarPath} "${kscript_args[@]}"

--- a/kscript
+++ b/kscript
@@ -24,5 +24,5 @@ abs_kscript_path=$(resolve_symlink $(absolute_path $0))
 jarPath=$(dirname $abs_kscript_path)/kscript.jar
 if [[ $(uname) == CYGWIN* ]]; then jarPath=$(cygpath -w ${jarPath}); fi
 
-## run it using command substitution to have just the user process once kscript is done
-exec $(kotlin -classpath ${jarPath} kscript.app.KscriptKt "$@")
+## run it
+exec kotlin -classpath ${jarPath} kscript.app.KscriptKt "$@"

--- a/kscript
+++ b/kscript
@@ -28,5 +28,29 @@ if [[ $(uname) == CYGWIN* ]]; then
     kotlin_home=$(cygpath -w ${KOTLIN_HOME})
 fi
 
+# from 'kotlinc'
+
+[ -n "$JAVA_OPTS" ] || JAVA_OPTS="-Xmx256M -Xms32M"
+
+declare -a java_args
+declare -a kscript_args
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -D*)
+      java_args=("${java_args[@]}" "$1")
+      shift
+      ;;
+    -J*)
+      java_args=("${java_args[@]}" "${1:2}")
+      shift
+      ;;
+    *)
+      kscript_args=("${kscript_args[@]}" "$1")
+      shift
+      ;;
+  esac
+done
+
 ## run it
-KOTLIN_HOME=${kotlin_home} exec java -jar ${jarPath} "$@"
+KOTLIN_HOME=${kotlin_home} exec java $JAVA_OPTS "${java_args[@]}" -jar ${jarPath} "${kscript_args[@]}"

--- a/kscript
+++ b/kscript
@@ -22,7 +22,11 @@ abs_kscript_path=$(resolve_symlink $(absolute_path $0))
 
 ## resolve application jar path from script location and convert to windows path when using cygwin
 jarPath=$(dirname $abs_kscript_path)/kscript.jar
-if [[ $(uname) == CYGWIN* ]]; then jarPath=$(cygpath -w ${jarPath}); fi
+kotlin_home=$KOTLIN_HOME
+if [[ $(uname) == CYGWIN* ]]; then
+    jarPath=$(cygpath -w ${jarPath})
+    kotlin_home=$(cygpath -w ${KOTLIN_HOME})
+fi
 
 ## run it
-exec kotlin -classpath ${jarPath} kscript.app.KscriptKt "$@"
+KOTLIN_HOME=${kotlin_home} exec java -jar ${jarPath} "$@"

--- a/src/main/kotlin/kscript/app/AppHelpers.kt
+++ b/src/main/kotlin/kscript/app/AppHelpers.kt
@@ -109,7 +109,6 @@ fun errorIf(value: Boolean, lazyMessage: () -> Any) {
 }
 
 fun quit(status: Int): Nothing {
-    print(if (status == 0) "true" else "false")
     exitProcess(status)
 }
 

--- a/src/main/kotlin/kscript/app/JarFileLoader.kt
+++ b/src/main/kotlin/kscript/app/JarFileLoader.kt
@@ -6,7 +6,7 @@ import java.net.URLClassLoader
 
 // https://dzone.com/articles/add-jar-file-java-load-path
 
-class JarFileLoader(urls: Array<URL>) : URLClassLoader(urls) {
+class JarFileLoader(urls: Array<URL> = arrayOf()) : URLClassLoader(urls) {
     fun addFile(path: String) {
         val urlPath = "jar:file://$path!/"
         addURL(URL(urlPath))

--- a/src/main/kotlin/kscript/app/JarFileLoader.kt
+++ b/src/main/kotlin/kscript/app/JarFileLoader.kt
@@ -1,0 +1,18 @@
+package kscript.app
+
+import java.io.File
+import java.net.URL
+import java.net.URLClassLoader
+
+// https://dzone.com/articles/add-jar-file-java-load-path
+
+class JarFileLoader(urls: Array<URL>) : URLClassLoader(urls) {
+    fun addFile(path: String) {
+        val urlPath = "jar:file://$path!/"
+        addURL(URL(urlPath))
+    }
+    fun addFile(file: File) {
+        addURL(file.toURI().toURL())
+    }
+}
+

--- a/src/main/kotlin/kscript/app/Kotlinc.kt
+++ b/src/main/kotlin/kscript/app/Kotlinc.kt
@@ -1,0 +1,45 @@
+package kscript.app
+
+import java.io.File
+
+class Kotlinc(val KOTLIN_HOME: String) {
+    val preloaderJar = File("${KOTLIN_HOME}${File.separatorChar}lib${File.separatorChar}kotlin-preloader.jar")
+    val baseArgs = listOf<String>("-cp", "${KOTLIN_HOME}${File.separatorChar}lib${File.separatorChar}kotlin-compiler.jar",
+            "org.jetbrains.kotlin.cli.jvm.K2JVMCompiler")
+    val cl = JarFileLoader()
+    val kscriptJarPath = getPath(System.getenv("KSCRIPT_JAR"))
+    init {
+        cl.addFile(preloaderJar)
+    }
+    val preloader = cl.loadClass("org.jetbrains.kotlin.preloading.Preloader").getDeclaredMethod("main", Array<String>::class.java)
+
+    fun getPath(jar: String?): String? = jar?.apply {
+        val file = File(jar)
+        if (file.isFile) file.absolutePath
+    }
+
+    fun classPathArgs(vararg paths: String?): List<String> {
+        val combinedClasspath = listOfNotNull(*paths).filter { it.isNotEmpty() }.joinToString(CP_SEPARATOR_CHAR)
+        return if (combinedClasspath.isNotEmpty()) {
+            listOf("-cp", combinedClasspath)
+        } else listOf()
+    }
+
+    fun runKotlinc(args: Collection<String>) {
+        preloader.invoke(cl, (baseArgs + args).toTypedArray())
+    }
+
+    fun compile(jarFile: File, scriptFile: File, wrapperFile: File?, classpath: String?) {
+        val baseArgs = listOf<String>("-Xskip-runtime-version-check",
+                "-d", jarFile.absolutePath, scriptFile.absolutePath)
+        val wrapperArgs =  listOfNotNull(wrapperFile?.absolutePath)
+        val cpArgs = classPathArgs(kscriptJarPath, classpath)
+        runKotlinc(baseArgs + wrapperArgs + cpArgs)
+    }
+
+    fun interactiveShell(jarFile: File, classpath: String?) {
+        val jarPath = if (jarFile.isFile) jarFile.absolutePath else null
+        val args = classPathArgs(kscriptJarPath, classpath, jarPath)
+        runKotlinc(args)
+    }
+}

--- a/src/main/kotlin/kscript/app/Kscript.kt
+++ b/src/main/kotlin/kscript/app/Kscript.kt
@@ -112,18 +112,6 @@ fun main(args: Array<String>) {
     // Extract kotlin arguments
     val kotlinOpts = script.collectRuntimeOptions()
 
-
-    //  Optionally enter interactive mode
-    if (docopt.getBoolean("interactive")) {
-        System.err.println("Creating REPL from ${scriptFile}")
-        //        System.err.println("kotlinc ${kotlinOpts} -classpath '${classpath}'")
-
-        val optionalCP = if (classpath != null && classpath.isNotEmpty()) "-classpath ${classpath}" else ""
-        println("kotlinc ${kotlinOpts} ${optionalCP}")
-
-        exitProcess(0)
-    }
-
     val scriptFileExt = scriptFile.extension
     val scriptCheckSum = md5(scriptFile)
 
@@ -166,6 +154,8 @@ fun main(args: Array<String>) {
     }
 
 
+    val kotlinc: Kotlinc by lazy { Kotlinc(KOTLIN_HOME!!)}
+
     // If scriplet jar ist not cached yet, build it
     if (!jarFile.isFile) {
         // disabled logging because it seems too much
@@ -178,12 +168,9 @@ fun main(args: Array<String>) {
         // }).forEach { it.delete() }
 
 
-        requireInPath("kotlinc")
-
-
         // create main-wrapper for kts scripts
 
-        val wrapperSrcArg = if (scriptFileExt == "kts") {
+        val wrapperFile = if (scriptFileExt == "kts") {
             val mainKotlin = File(createTempDir("kscript"), execClassName + ".kt")
 
             val classReference = (script.pckg ?: "") + className
@@ -199,20 +186,24 @@ fun main(args: Array<String>) {
                 }
             }
             """.trimIndent())
+            mainKotlin
+        } else null
 
-            "'${mainKotlin.absolutePath}'"
-        } else {
-            ""
-        }
+        kotlinc.compile(jarFile, scriptFile, wrapperFile, classpath)
+    }
 
-        val scriptCompileResult = evalBash("kotlinc -classpath '$classpath' -d '${jarFile.absolutePath}' '${scriptFile.absolutePath}' ${wrapperSrcArg}")
-        with(scriptCompileResult) {
-            errorIf(exitCode != 0) { "compilation of '$scriptResource' failed\n$stderr" }
-        }
+    //  Optionally enter interactive mode
+    if (docopt.getBoolean("interactive")) {
+        System.err.println("Creating REPL from ${scriptFile}")
+        //        System.err.println("kotlinc ${kotlinOpts} -classpath '${classpath}'")
+
+        val optionalCP = if (classpath != null && classpath.isNotEmpty()) "-classpath ${classpath}" else ""
+        kotlinc.interactiveShell(jarFile, classpath)
+        exitProcess(0)
     }
 
     // run the main method
-    val cl = JarFileLoader(arrayOf<URL>())
+    val cl = JarFileLoader()
     if (classpath != null && classpath.isNotEmpty()) {
         classpath.split(CP_SEPARATOR_CHAR).forEach { cl.addFile(it) }
     }

--- a/src/main/kotlin/kscript/app/Kscript.kt
+++ b/src/main/kotlin/kscript/app/Kscript.kt
@@ -41,6 +41,7 @@ Options:
  -t --text               Enable stdin support API for more streamlined text processing
  --idea                  Open script in temporary Intellij session
  -s --silent             Suppress status logging to stderr
+ -J<arg>                 -J is stripped and <arg> passed to Java as-is
 
 Copyright : 2017 Holger Brandl
 License   : MIT

--- a/src/main/kotlin/kscript/app/Kscript.kt
+++ b/src/main/kotlin/kscript/app/Kscript.kt
@@ -109,9 +109,6 @@ fun main(args: Array<String>) {
 
     val classpath = resolveDependencies(dependencies, customRepos, loggingEnabled)
 
-    // Extract kotlin arguments
-    val kotlinOpts = script.collectRuntimeOptions()
-
     val scriptFileExt = scriptFile.extension
     val scriptCheckSum = md5(scriptFile)
 

--- a/src/main/kotlin/kscript/app/Kscript.kt
+++ b/src/main/kotlin/kscript/app/Kscript.kt
@@ -205,9 +205,6 @@ fun main(args: Array<String>) {
         classpath.split(CP_SEPARATOR_CHAR).forEach { cl.addFile(it) }
     }
     cl.addFile(jarFile)
-    // passing string is not working for cygwin or git-bash
-    val scriptRuntime = File("${KOTLIN_HOME}${File.separatorChar}lib${File.separatorChar}kotlin-script-runtime.jar")
-    cl.addFile(scriptRuntime)
     val mainMethod = cl.loadClass(execClassName).getDeclaredMethod("main", Array<String>::class.java)
     mainMethod.invoke(cl, userArgs.toTypedArray())
 }

--- a/src/main/kotlin/kscript/app/Script.kt
+++ b/src/main/kotlin/kscript/app/Script.kt
@@ -180,35 +180,3 @@ fun Script.collectRepos(): List<MavenRepo> {
 
     // todo add credential support https://stackoverflow.com/questions/36282168/how-to-add-custom-maven-repository-to-gradle
 }
-
-
-//
-// Runtime Configuration
-//
-
-
-/**
- * Collect runtime options declared using //KOTLIN_OPTS or @file:KotlinOpts
- */
-fun Script.collectRuntimeOptions(): String {
-    val koptsPrefix = "//KOTLIN_OPTS "
-
-    var kotlinOpts = lines.
-        filter { it.startsWith(koptsPrefix) }.
-        map { it.replaceFirst(koptsPrefix, "").trim() }
-
-    //support for @file:KotlinOpts see #47
-    val annotatonPrefix = "^@file:KotlinOpts[(]".toRegex()
-    kotlinOpts += lines
-        .filter { it.contains(annotatonPrefix) }
-        .map { it.replaceFirst(annotatonPrefix, "").split(")")[0] }
-        .map { it.trim(' ', '"') }
-
-
-    // Append $KSCRIPT_KOTLIN_OPTS if defined in the parent environment
-    System.getenv()["KSCRIPT_KOTLIN_OPTS"]?.run {
-        kotlinOpts = kotlinOpts + this
-    }
-
-    return kotlinOpts.joinToString(" ")
-}


### PR DESCRIPTION
Hi,

I changed two things to improve the startup time of kscript.
- Instead of generating 'kotlin or kotlinc' command, the main method of the script is called (Java needs to be started only once, not twice)
- Call java with a fat jar instead of kotlin

Naturally, KOTLIN_OPTS cannot be supported anymore. Instead, users can supply -J arguments. (ex. kscript -J-Xmx8G memory-hungry-script.kts)
