### PR TITLE
Startup Time Improvement

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,15 +5,35 @@ apply plugin: 'java'
 apply plugin: 'kotlin'
 //apply plugin: 'maven'
 apply plugin: 'com.github.johnrengelman.shadow'
+apply plugin: 'application'
 
+sourceSets {
+    main.java.srcDirs += 'src/main/kotlin/'
+    test.java.srcDirs += 'src/test/kotlin/'
+}
+
+jar {
+    manifest {
+        attributes 'Main-Class': 'kscript.app.KscriptKt'
+    }
+    from {
+        configurations.compile.collect {
+            it.isDirectory() ? it : zipTree(it)
+        }
+    }
+}
+
+mainClassName = 'kscript.app.KscriptKt'
 
 dependencies {
 //    https://docs.gradle.org/current/userguide/java_plugin.html#sec:java_plugin_and_dependency_management
-    compileOnly "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-//    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+//    compileOnly "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-script-runtime:$kotlin_version"
 
 //    compile "org.apache.commons:commons-csv:1.3"
     compile "com.offbytwo:docopt:0.6.0.20150202"
+
 
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile "io.kotlintest:kotlintest:2.0.7"

--- a/kscript
+++ b/kscript
@@ -22,7 +22,10 @@ abs_kscript_path=$(resolve_symlink $(absolute_path $0))
 
 ## resolve application jar path from script location and convert to windows path when using cygwin
 jarPath=$(dirname $abs_kscript_path)/kscript.jar
-if [[ $(uname) == CYGWIN* ]]; then jarPath=$(cygpath -w ${jarPath}); fi
+if [[ $(uname) == CYGWIN* ]]; then
+    jarPath=$(cygpath -w ${jarPath})
+    [[ ! -z $KOTLIN_HOME ]] && KOTLIN_HOME=$(cygpath -w ${KOTLIN_HOME})
+fi
 
 ## run it
-exec kotlin -classpath ${jarPath} kscript.app.KscriptKt "$@"
+exec java -jar ${jarPath} "$@"

--- a/kscript
+++ b/kscript
@@ -24,5 +24,5 @@ abs_kscript_path=$(resolve_symlink $(absolute_path $0))
 jarPath=$(dirname $abs_kscript_path)/kscript.jar
 if [[ $(uname) == CYGWIN* ]]; then jarPath=$(cygpath -w ${jarPath}); fi
 
-## run it using command substitution to have just the user process once kscript is done
-exec $(kotlin -classpath ${jarPath} kscript.app.KscriptKt "$@")
+## run it
+exec kotlin -classpath ${jarPath} kscript.app.KscriptKt "$@"

--- a/kscript
+++ b/kscript
@@ -27,5 +27,29 @@ if [[ $(uname) == CYGWIN* ]]; then
     [[ ! -z $KOTLIN_HOME ]] && KOTLIN_HOME=$(cygpath -w ${KOTLIN_HOME})
 fi
 
+# from 'kotlinc'
+
+[ -n "$JAVA_OPTS" ] || JAVA_OPTS="-Xmx256M -Xms32M"
+
+declare -a java_args
+declare -a kscript_args
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -D*)
+      java_args=("${java_args[@]}" "$1")
+      shift
+      ;;
+    -J*)
+      java_args=("${java_args[@]}" "${1:2}")
+      shift
+      ;;
+    *)
+      kscript_args=("${kscript_args[@]}" "$1")
+      shift
+      ;;
+  esac
+done
+
 ## run it
-exec java -jar ${jarPath} "$@"
+exec java $JAVA_OPTS "${java_args[@]}" -jar ${jarPath} "${kscript_args[@]}"

--- a/src/main/kotlin/kscript/app/AppHelpers.kt
+++ b/src/main/kotlin/kscript/app/AppHelpers.kt
@@ -109,7 +109,6 @@ fun errorIf(value: Boolean, lazyMessage: () -> Any) {
 }
 
 fun quit(status: Int): Nothing {
-    print(if (status == 0) "true" else "false")
     exitProcess(status)
 }
 

--- a/src/main/kotlin/kscript/app/JarFileLoader.kt
+++ b/src/main/kotlin/kscript/app/JarFileLoader.kt
@@ -6,7 +6,7 @@ import java.net.URLClassLoader
 
 // https://dzone.com/articles/add-jar-file-java-load-path
 
-class JarFileLoader(urls: Array<URL>) : URLClassLoader(urls) {
+class JarFileLoader(urls: Array<URL> = arrayOf()) : URLClassLoader(urls) {
     fun addFile(path: String) {
         val urlPath = "jar:file://$path!/"
         addURL(URL(urlPath))

--- a/src/main/kotlin/kscript/app/JarFileLoader.kt
+++ b/src/main/kotlin/kscript/app/JarFileLoader.kt
@@ -1,0 +1,18 @@
+package kscript.app
+
+import java.io.File
+import java.net.URL
+import java.net.URLClassLoader
+
+// https://dzone.com/articles/add-jar-file-java-load-path
+
+class JarFileLoader(urls: Array<URL>) : URLClassLoader(urls) {
+    fun addFile(path: String) {
+        val urlPath = "jar:file://$path!/"
+        addURL(URL(urlPath))
+    }
+    fun addFile(file: File) {
+        addURL(file.toURI().toURL())
+    }
+}
+

--- a/src/main/kotlin/kscript/app/Kotlinc.kt
+++ b/src/main/kotlin/kscript/app/Kotlinc.kt
@@ -1,0 +1,39 @@
+package kscript.app
+
+import java.io.File
+
+class Kotlinc(val KOTLIN_HOME: String) {
+    val cl = JarFileLoader()
+    val preloaderJar = File("${KOTLIN_HOME}${File.separatorChar}lib${File.separatorChar}kotlin-preloader.jar")
+    init {
+        cl.addFile(preloaderJar)
+    }
+    val baseArgs = listOf<String>("-cp", "${KOTLIN_HOME}${File.separatorChar}lib${File.separatorChar}kotlin-compiler.jar",
+            "org.jetbrains.kotlin.cli.jvm.K2JVMCompiler")
+    val preloaderMain = cl.loadClass("org.jetbrains.kotlin.preloading.Preloader").getDeclaredMethod("main", Array<String>::class.java)
+
+    fun classPathArgs(vararg paths: String?): List<String> {
+        val combinedClasspath = listOfNotNull(*paths).filter { it.isNotEmpty() }.joinToString(CP_SEPARATOR_CHAR)
+        return if (combinedClasspath.isNotEmpty()) {
+            listOf("-cp", combinedClasspath)
+        } else listOf()
+    }
+
+    fun runKotlinc(args: Collection<String>) {
+        preloaderMain.invoke(cl, (baseArgs + args).toTypedArray())
+    }
+
+    fun compile(jarFile: File, scriptFile: File, wrapperFile: File?, classpath: String?) {
+        val baseArgs = listOf<String>("-Xskip-runtime-version-check",
+                "-d", jarFile.absolutePath, scriptFile.absolutePath)
+        val wrapperArgs =  listOfNotNull(wrapperFile?.absolutePath)
+        val cpArgs = classPathArgs(classpath)
+        runKotlinc(baseArgs + wrapperArgs + cpArgs)
+    }
+
+    fun interactiveShell(jarFile: File, classpath: String?) {
+        val jarPath = if (jarFile.isFile) jarFile.absolutePath else null
+        val args = classPathArgs(classpath, jarPath)
+        runKotlinc(args)
+    }
+}

--- a/src/main/kotlin/kscript/app/Kscript.kt
+++ b/src/main/kotlin/kscript/app/Kscript.kt
@@ -41,6 +41,7 @@ Options:
  -t --text               Enable stdin support API for more streamlined text processing
  --idea                  Open script in temporary Intellij session
  -s --silent             Suppress status logging to stderr
+ -J<arg>                 -J is stripped and <arg> passed to Java as-is
 
 Copyright : 2017 Holger Brandl
 License   : MIT

--- a/src/main/kotlin/kscript/app/Kscript.kt
+++ b/src/main/kotlin/kscript/app/Kscript.kt
@@ -205,9 +205,6 @@ fun main(args: Array<String>) {
         classpath.split(CP_SEPARATOR_CHAR).forEach { cl.addFile(it) }
     }
     cl.addFile(jarFile)
-    // passing string is not working for cygwin or git-bash
-    val scriptRuntime = File("${KOTLIN_HOME}${File.separatorChar}lib${File.separatorChar}kotlin-script-runtime.jar")
-    cl.addFile(scriptRuntime)
     val mainMethod = cl.loadClass(execClassName).getDeclaredMethod("main", Array<String>::class.java)
     mainMethod.invoke(cl, userArgs.toTypedArray())
 }

--- a/src/main/kotlin/kscript/app/Script.kt
+++ b/src/main/kotlin/kscript/app/Script.kt
@@ -180,35 +180,3 @@ fun Script.collectRepos(): List<MavenRepo> {
 
     // todo add credential support https://stackoverflow.com/questions/36282168/how-to-add-custom-maven-repository-to-gradle
 }
-
-
-//
-// Runtime Configuration
-//
-
-
-/**
- * Collect runtime options declared using //KOTLIN_OPTS or @file:KotlinOpts
- */
-fun Script.collectRuntimeOptions(): String {
-    val koptsPrefix = "//KOTLIN_OPTS "
-
-    var kotlinOpts = lines.
-        filter { it.startsWith(koptsPrefix) }.
-        map { it.replaceFirst(koptsPrefix, "").trim() }
-
-    //support for @file:KotlinOpts see #47
-    val annotatonPrefix = "^@file:KotlinOpts[(]".toRegex()
-    kotlinOpts += lines
-        .filter { it.contains(annotatonPrefix) }
-        .map { it.replaceFirst(annotatonPrefix, "").split(")")[0] }
-        .map { it.trim(' ', '"') }
-
-
-    // Append $KSCRIPT_KOTLIN_OPTS if defined in the parent environment
-    System.getenv()["KSCRIPT_KOTLIN_OPTS"]?.run {
-        kotlinOpts = kotlinOpts + this
-    }
-
-    return kotlinOpts.joinToString(" ")
-}

--- a/src/test/kotlin/Tests.kt
+++ b/src/test/kotlin/Tests.kt
@@ -70,28 +70,6 @@ class Tests {
 
     }
 
-
-    // combine kotlin opts spread over multiple lines
-    @Test
-    fun optsCollect() {
-        val lines = listOf(
-            "//KOTLIN_OPTS -foo 3 'some file.txt'",
-            "//KOTLIN_OPTS  --bar"
-        )
-
-        Script(lines).collectRuntimeOptions() shouldBe "-foo 3 'some file.txt' --bar"
-    }
-
-    @Test
-    fun annotOptsCollect() {
-        val lines = listOf(
-            "//KOTLIN_OPTS -foo 3 'some file.txt'",
-            """@file:KotlinOpts("--bar")"""
-        )
-
-        Script(lines).collectRuntimeOptions() shouldBe "-foo 3 'some file.txt' --bar"
-    }
-
     @Test
     fun detectEntryPoint() {
         assertTrue(isEntryPointDirective("//ENTRY Foo"))


### PR DESCRIPTION
Hi,

I made two changes to reduce the statup time of kscript:
- Call the main method of the script using classloader instead of excuting kotlin again (No double java startup time)
- Make a fat jar to call Java instead of Kotlin 

One drawback is KOTLIN_OPTS cannot be supported anymore, but not users can specify  -J<arg> Java options. (ex - kscript -J-Xmx8G memory-hungry-script.kts)
 