### PR TITLE
Startup Time Improvement

### DIFF
--- a/kscript
+++ b/kscript
@@ -24,5 +24,20 @@ abs_kscript_path=$(resolve_symlink $(absolute_path $0))
 jarPath=$(dirname $abs_kscript_path)/kscript.jar
 if [[ $(uname) == CYGWIN* ]]; then jarPath=$(cygpath -w ${jarPath}); fi
 
-## run it using command substitution to have just the user process once kscript is done
-exec $(kotlin -classpath ${jarPath} kscript.app.KscriptKt "$@")
+followupFile=followup-$$
+
+## run it
+FOLLOWUP_FILE=$followupFile kotlin -classpath ${jarPath} kscript.app.KscriptKt "$@"
+result=$?
+
+followupPath=${HOME}/.kscript/${followupFile}
+
+
+
+if [[ -f $followupPath ]]; then
+    cmd=$(cat $followupPath)
+    "${RMCMD:=rm}" -f $followupPath
+    exec $cmd
+else
+    exit $result
+fi

--- a/kscript
+++ b/kscript
@@ -22,17 +22,42 @@ abs_kscript_path=$(resolve_symlink $(absolute_path $0))
 
 ## resolve application jar path from script location and convert to windows path when using cygwin
 jarPath=$(dirname $abs_kscript_path)/kscript.jar
-if [[ $(uname) == CYGWIN* ]]; then jarPath=$(cygpath -w ${jarPath}); fi
+if [[ $(uname) == CYGWIN* ]]; then
+    jarPath=$(cygpath -w ${jarPath})
+    [[ ! -z $KOTLIN_HOME ]] && KOTLIN_HOME=$(cygpath -w ${KOTLIN_HOME})
+fi
+
+# from 'kotlinc'
+
+[ -n "$JAVA_OPTS" ] || JAVA_OPTS="-Xmx256M -Xms32M"
+
+declare -a java_args
+declare -a kscript_args
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -D*)
+      java_args=("${java_args[@]}" "$1")
+      shift
+      ;;
+    -J*)
+      java_args=("${java_args[@]}" "$1")
+      shift
+      ;;
+    *)
+      kscript_args=("${kscript_args[@]}" "$1")
+      shift
+      ;;
+  esac
+done
 
 followupFile=followup-$$
 
 ## run it
-FOLLOWUP_FILE=$followupFile kotlin -classpath ${jarPath} kscript.app.KscriptKt "$@"
+FOLLOWUP_FILE=$followupFile kotlin "${java_args[@]}" -classpath ${jarPath} kscript.app.KscriptKt "${kscript_args[@]}"
 result=$?
 
 followupPath=${HOME}/.kscript/${followupFile}
-
-
 
 if [[ -f $followupPath ]]; then
     cmd=$(cat $followupPath)

--- a/src/main/kotlin/kscript/app/AppHelpers.kt
+++ b/src/main/kotlin/kscript/app/AppHelpers.kt
@@ -109,7 +109,6 @@ fun errorIf(value: Boolean, lazyMessage: () -> Any) {
 }
 
 fun quit(status: Int): Nothing {
-    print(if (status == 0) "true" else "false")
     exitProcess(status)
 }
 

--- a/src/main/kotlin/kscript/app/JarFileLoader.kt
+++ b/src/main/kotlin/kscript/app/JarFileLoader.kt
@@ -1,0 +1,14 @@
+package kscript.app
+
+import java.io.File
+import java.net.URL
+import java.net.URLClassLoader
+
+// https://dzone.com/articles/add-jar-file-java-load-path
+
+class JarFileLoader(urls: Array<URL> = arrayOf()) : URLClassLoader(urls) {
+    fun addFile(file: File) {
+        addURL(file.toURI().toURL())
+    }
+}
+

--- a/src/main/kotlin/kscript/app/Kotlinc.kt
+++ b/src/main/kotlin/kscript/app/Kotlinc.kt
@@ -1,0 +1,39 @@
+package kscript.app
+
+import java.io.File
+
+class Kotlinc(val KOTLIN_HOME: String) {
+    val cl = JarFileLoader()
+    val preloaderJar = File("${KOTLIN_HOME}${File.separatorChar}lib${File.separatorChar}kotlin-preloader.jar")
+    init {
+        cl.addFile(preloaderJar)
+    }
+    val baseArgs = listOf<String>("-cp", "${KOTLIN_HOME}${File.separatorChar}lib${File.separatorChar}kotlin-compiler.jar",
+            "org.jetbrains.kotlin.cli.jvm.K2JVMCompiler")
+    val preloaderMain = cl.loadClass("org.jetbrains.kotlin.preloading.Preloader").getDeclaredMethod("main", Array<String>::class.java)
+
+    fun classPathArgs(vararg paths: String?): List<String> {
+        val combinedClasspath = listOfNotNull(*paths).filter { it.isNotEmpty() }.joinToString(CP_SEPARATOR_CHAR)
+        return if (combinedClasspath.isNotEmpty()) {
+            listOf("-cp", combinedClasspath)
+        } else listOf()
+    }
+
+    fun runKotlinc(args: Collection<String>) {
+        preloaderMain.invoke(cl, (baseArgs + args).toTypedArray())
+    }
+
+    fun compile(jarFile: File, scriptFile: File, wrapperFile: File?, classpath: String?) {
+        val baseArgs = listOf<String>("-Xskip-runtime-version-check",
+                "-d", jarFile.absolutePath, scriptFile.absolutePath)
+        val wrapperArgs =  listOfNotNull(wrapperFile?.absolutePath)
+        val cpArgs = classPathArgs(classpath)
+        runKotlinc(baseArgs + wrapperArgs + cpArgs)
+    }
+
+    fun interactiveShell(jarFile: File, classpath: String?) {
+        val jarPath = if (jarFile.isFile) jarFile.absolutePath else null
+        val args = classPathArgs(classpath, jarPath)
+        runKotlinc(args)
+    }
+}

--- a/src/main/kotlin/kscript/app/Kscript.kt
+++ b/src/main/kotlin/kscript/app/Kscript.kt
@@ -41,6 +41,7 @@ Options:
  -t --text               Enable stdin support API for more streamlined text processing
  --idea                  Open script in temporary Intellij session
  -s --silent             Suppress status logging to stderr
+ -J<arg>                 -J is stripped and <arg> passed to Java as-is
 
 Copyright : 2017 Holger Brandl
 License   : MIT

--- a/test/test_suite.sh
+++ b/test/test_suite.sh
@@ -122,10 +122,10 @@ export -f resolve_deps
 assert_stderr "resolve_deps log4j:log4j:1.2.14" "${HOME}/.m2/repository/log4j/log4j/1.2.14/log4j-1.2.14.jar"
 
 ## impossible version
-assert "resolve_deps log4j:log4j:9.8.76" "false"
+assert_raises "resolve_deps log4j:log4j:9.8.76" 1
 
 ## wrong format should exit with 1
-assert "resolve_deps log4j:1.0" "false"
+assert_raises "resolve_deps log4j:1.0" 1
 
 assert_stderr "resolve_deps log4j:1.0" "[ERROR] Invalid dependency locator: 'log4j:1.0'.  Expected format is groupId:artifactId:version[:classifier]"
 


### PR DESCRIPTION
Hi,

I made a change to reduce the statup time of kscript:

- Call the main method of the script using classloader instead of excuting kotlin again (No double java startup time) (Scripts using KOTLIN_OPTS are exceptions)

In addition to KOTLIN_OPTS, users can specify -J Java options to kscript directly. (ex - kscript -J-Xmx8G memory-hungry-script.kts). If both of KOTLIN_OPTS and -J options are supplied, only KOTLIN_OPTS will be used to run the script.

(edit1 - KOTLIN_OPTS support)
(edit2 - remove the mention of fat-jar)