### PR TITLE
Fixed space-containing argument propagation

### DIFF
--- a/kscript
+++ b/kscript
@@ -25,4 +25,4 @@ jarPath=$(dirname $abs_kscript_path)/kscript.jar
 if [[ $(uname) == CYGWIN* ]]; then jarPath=$(cygpath -w ${jarPath}); fi
 
 ## run it using command substitution to have just the user process once kscript is done
-exec $(kotlin -classpath ${jarPath} kscript.app.KscriptKt "$@")
+eval "exec $(kotlin -classpath ${jarPath} kscript.app.KscriptKt "$@")"

--- a/src/main/kotlin/kscript/app/Kscript.kt
+++ b/src/main/kotlin/kscript/app/Kscript.kt
@@ -237,8 +237,8 @@ fun main(args: Array<String>) {
     }
 
 
-    // print the final command to be run by exec
-    val joinedUserArgs = userArgs.joinToString(" ")
+    // print the final command to be run by eval+exec
+    val joinedUserArgs = userArgs.map { "\"${it.replace("\"", "\\\"")}\"" }.joinToString(" ")
 
     //if requested try to package the into a standalone binary
     if (docopt.getBoolean("package")) {


### PR DESCRIPTION
Fixes https://github.com/holgerbrandl/kscript/issues/98

Test:
- ensure `kscript "println(args.asList())" 0 1 "2 3" '4 5' '6"7' "7'8"` prints: `[0, 1, 2 3, 4 5, 6"7, 7'8]`
- same as above, but for `--package`d script