### PR TITLE
Support --idea with includes (#103)

### DIFF
--- a/src/main/kotlin/kscript/app/ResolveIncludes.kt
+++ b/src/main/kotlin/kscript/app/ResolveIncludes.kt
@@ -29,8 +29,7 @@ fun resolveIncludes(template: File, includeContext: URI = template.parentFile.to
                 val include = extractIncludeTarget(it)
 
                 val includeURL = when {
-                    include.startsWith("http://") -> URL(include)
-                    include.startsWith("https://") -> URL(include)
+                    isUrl(include) -> URL(include)
                     include.startsWith("/") -> File(include).toURI().toURL()
                     else -> includeContext.resolve(URI(include.removePrefix("./"))).toURL()
                 }
@@ -51,13 +50,14 @@ fun resolveIncludes(template: File, includeContext: URI = template.parentFile.to
     return script.consolidateStructure().createTmpScript()
 }
 
+internal fun isUrl(s: String) = s.startsWith("http://") || s.startsWith("https://")
 
 private const val INCLUDE_ANNOT_PREFIX = "@file:Include("
 
-private fun isIncludeDirective(line: String) = line.startsWith("//INCLUDE") || line.startsWith(INCLUDE_ANNOT_PREFIX)
+internal fun isIncludeDirective(line: String) = line.startsWith("//INCLUDE") || line.startsWith(INCLUDE_ANNOT_PREFIX)
 
 
-private fun extractIncludeTarget(incDirective: String) = when {
+internal fun extractIncludeTarget(incDirective: String) = when {
     incDirective.startsWith(INCLUDE_ANNOT_PREFIX) -> incDirective
         .replaceFirst(INCLUDE_ANNOT_PREFIX, "")
         .split(")")[0].trim(' ', '"')

--- a/src/test/kotlin/Tests.kt
+++ b/src/test/kotlin/Tests.kt
@@ -160,4 +160,10 @@ class Tests {
 
         result.readText() shouldBe (expected.readText())
     }
+
+    @Test
+    fun test_include_detection() {
+        val script = Script(File("test/resources/includes/include_variations.kts"))
+        script.includes.map { it.file.name } shouldBe List(4) { "include_${it+1}.kt" }
+    }
 }


### PR DESCRIPTION
Caveat: only items declared in .kt files (not .kts) are picked up
by idea when resolving terms in its neighbours

Test:
- create a file that `//INCLUDE`s a relative .kt script, and a .kt url
- pass it to `kscript --idea` and ensure all terms from its includes are non-red
- execute it and ensure no compilation/runtime errors