### PR TITLE
allow to include same file from multiple files

### DIFF
--- a/src/main/kotlin/kscript/app/AppHelpers.kt
+++ b/src/main/kotlin/kscript/app/AppHelpers.kt
@@ -241,11 +241,15 @@ sourceSets.main.java.srcDirs 'src'
         // https://stackoverflow.com/questions/17926459/creating-a-symbolic-link-with-java
         createSymLink(File(this, scriptFile.name), scriptFile)
 
-
+        val includedFiles = mutableSetOf<String>()
         // also symlink all includes
         includeURLs.forEach {
             val includeFileName = it.toURI().path.split("/").last()
-
+            //make sure not to include each file more than once (it will fail)
+            if (!includedFiles.add(includeFileName)) {
+                return@forEach
+            }
+            
             val includeFile = when {
                 it.protocol == "file" -> File(it.toURI())
                 else -> fetchFromURL(it.toString())

--- a/src/main/kotlin/kscript/app/AppHelpers.kt
+++ b/src/main/kotlin/kscript/app/AppHelpers.kt
@@ -241,15 +241,11 @@ sourceSets.main.java.srcDirs 'src'
         // https://stackoverflow.com/questions/17926459/creating-a-symbolic-link-with-java
         createSymLink(File(this, scriptFile.name), scriptFile)
 
-        val includedFiles = mutableSetOf<String>()
         // also symlink all includes
-        includeURLs.forEach {
-            val includeFileName = it.toURI().path.split("/").last()
-            //make sure not to include each file more than once (it will fail)
-            if (!includedFiles.add(includeFileName)) {
-                return@forEach
-            }
-            
+        includeURLs.distinctBy { it.fileName() }
+          .forEach {
+            val includeFileName = it.fileName()
+                        
             val includeFile = when {
                 it.protocol == "file" -> File(it.toURI())
                 else -> fetchFromURL(it.toString())
@@ -262,6 +258,7 @@ sourceSets.main.java.srcDirs 'src'
     return "idea ${tmpProjectDir.absolutePath}"
 }
 
+private fun URL.fileName() = this.toURI().path.split("/").last()
 
 private fun createSymLink(link: File, target: File) {
     try {

--- a/src/main/kotlin/kscript/app/AppHelpers.kt
+++ b/src/main/kotlin/kscript/app/AppHelpers.kt
@@ -244,14 +244,13 @@ sourceSets.main.java.srcDirs 'src'
         // also symlink all includes
         includeURLs.distinctBy { it.fileName() }
           .forEach {
-            val includeFileName = it.fileName()
-                        
+            
             val includeFile = when {
                 it.protocol == "file" -> File(it.toURI())
                 else -> fetchFromURL(it.toString())
             }
 
-            createSymLink(File(this, includeFileName), includeFile)
+            createSymLink(File(this, it.fileName()), includeFile)
         }
     }
 

--- a/test/resources/diamond.kts
+++ b/test/resources/diamond.kts
@@ -1,0 +1,6 @@
+#!/usr/bin/env kscript
+
+
+@file:Include("includes/include_3.kt")
+@file:Include("includes/include_3.kt")
+


### PR DESCRIPTION
add a set of already added files and check if files was already added, in such case do not try to add it again

This happened to me while trying to include same files from multiple files (diamond topology)

got this exception when starting an idea project:

Exception in thread "main" kotlin.io.FileAlreadyExistsException: .../kscripts/utils.kt -> /Users/oshai/.kscript/kscript_tmp_project__ksuite.kts_1530089926297/src/utils.kt: The destination file already exists.
        at kotlin.io.FilesKt__UtilsKt.copyTo(Utils.kt:193)
        at kotlin.io.FilesKt__UtilsKt.copyTo$default(Utils.kt:184)
        at kscript.app.AppHelpersKt.createSymLink(AppHelpers.kt:267)
        at kscript.app.AppHelpersKt.launchIdeaWithKscriptlet(AppHelpers.kt:254)
        at kscript.app.KscriptKt.main(Kscript.kt:140)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.jetbrains.kotlin.runner.AbstractRunner.run(runners.kt:61)
        at org.jetbrains.kotlin.runner.Main.run(Main.kt:109)
        at org.jetbrains.kotlin.runner.Main.main(Main.kt:119)
