### PR TITLE
Adds IncludeDir and IncludeDirs directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ The following directives supported by `kscript` to configure scripts:
 * `//DEPS` to declare dependencies with gradle-style locators
 * `//KOTLIN_OPTS`  to configure the kotlin/java runtime environment
 * `//INCLUDE` to source kotlin files into the script
+* `//INCLUDE_DIR` to source all kotlin files in a directory into the script
+* `//INCLUDE_DIRS` to recursively source all kotlin files in a directory into the script
 * `//ENTRY` to declare the application entrypoint for kotlin `*.kt` applications
 
 
@@ -255,7 +257,9 @@ println(robustMean)
 ```
 The argument can be an URL, absolute or relative file path. Note that URLs used in include directives are cached locally to speed up processing, that is `kscript` won't fetch URLs again unless the user actively clears the cache with `kscript --clear-cache`.
 
-For more examples see [here](test/resources/includes/include_variations.kts).
+Similarly, you can use `//INCLUDE_DIR` to directly include all files in a single directory, or `//INCLUDE_DIRS` to recursively include all files in a directory and its subdirectories.
+
+For more examples see [INCLUDE here](test/resources/includes/include_variations.kts), [INCLUDE_DIR here](test/resources/include_dir/input.kts), or [INCLUDE_DIRS here](test/resources/include_dirs/input.kts)
 
 
 ### Use `//ENTRY` to run applications with `main` method
@@ -317,6 +321,8 @@ Using annotations instead of comment directives to configure scripts is cleaner 
 
 // Include helper scripts without deployment or prior compilation
 @file:Include("util.kt")
+@file:IncludeDir("utils")
+@file:IncludeDirs("utils")
 
 
 // Define kotlin options

--- a/src/main/kotlin/kscript/app/ResolveIncludes.kt
+++ b/src/main/kotlin/kscript/app/ResolveIncludes.kt
@@ -8,6 +8,7 @@ import java.net.URL
 /**
  * @author Holger Brandl
  * @author Ilan Pillemer
+ * @author Casey Brooks
  */
 
 const val PACKAGE_STATEMENT_PREFIX = "package "
@@ -19,57 +20,162 @@ data class IncludeResult(val scriptFile: File, val includes: List<URL> = emptyLi
 fun resolveIncludes(template: File, includeContext: URI = template.parentFile.toURI()): IncludeResult {
     var script = Script(template)
 
-    // just rewrite user scripts if includes a
-    if (!script.any { isIncludeDirective(it) }) {
+    val includeables = listOf(IncludeDirective(), IncludeDirDirective(), IncludeDirsDirective())
+
+    // just rewrite user scripts if there are no includes
+    if (!script.any { line -> includeables.any { includeable -> includeable.lineMatches(line) }}) {
         return IncludeResult(template)
     }
 
     val includes = emptyList<URL>().toMutableList()
 
     // resolve as long as it takes. YAGNI but we do because we can!
-    while (script.any { isIncludeDirective(it) }) {
-        script = script.flatMap {
-            if (isIncludeDirective(it)) {
-                val include = extractIncludeTarget(it)
+    while (script.any { line -> includeables.any { includeable -> includeable.lineMatches(line) }}) {
+        script = script.flatMap { line ->
+            val includable: Includable? = includeables.find { it.lineMatches(line) }
 
-                val includeURL = when {
-                    isUrl(include) -> URL(include)
-                    include.startsWith("/") -> File(include).toURI().toURL()
-                    else -> includeContext.resolve(URI(include.removePrefix("./"))).toURL()
-                }
-
-                includes.add(includeURL)
-
-                try {
-                    includeURL.readText().lines()
-                } catch (e: FileNotFoundException) {
-                    errorMsg("Failed to resolve //INCLUDE '${include}'")
-                    System.err.println(e.message?.lines()!!.map { it.prependIndent("[kscript] [ERROR] ") })
-                    quit(1)
-                }
-            } else {
-                listOf(it)
+            val result: Pair<List<URL>, List<String>>
+            if(includable != null) {
+                result = includable.handleTarget(includable.extractTarget(line), includeContext)
             }
+            else {
+                result = Pair(emptyList(), listOf(line))
+            }
+
+            includes.addAll(result.first)
+            result.second
         }.let { script.copy(it) }
     }
 
     return IncludeResult(script.consolidateStructure().createTmpScript(), includes)
 }
 
-internal fun isUrl(s: String) = s.startsWith("http://") || s.startsWith("https://")
+/**
+ * Base class used for detecting and handling include directives
+ */
+private abstract class Includable(
+        protected val commentPrefix: String,
+        protected val annotationPrefix: String
+) {
 
-private const val INCLUDE_ANNOT_PREFIX = "@file:Include("
+    fun lineMatches(line: String): Boolean {
+        return line.startsWith(commentPrefix) || line.startsWith(annotationPrefix)
+    }
 
-internal fun isIncludeDirective(line: String) = line.startsWith("//INCLUDE") || line.startsWith(INCLUDE_ANNOT_PREFIX)
+    fun extractTarget(incDirective: String): String {
+        return if (incDirective.startsWith(annotationPrefix)) {
+            incDirective
+                    .replaceFirst(annotationPrefix, "")
+                    .split(")")[0]
+                    .trim(' ', '"')
+        }
+        else {
+            incDirective.replaceFirst(commentPrefix, "").trim()
+        }
+    }
 
-
-internal fun extractIncludeTarget(incDirective: String) = when {
-    incDirective.startsWith(INCLUDE_ANNOT_PREFIX) -> incDirective
-        .replaceFirst(INCLUDE_ANNOT_PREFIX, "")
-        .split(")")[0].trim(' ', '"')
-    else -> incDirective.split("[ ]+".toRegex()).last()
+    abstract fun handleTarget(include: String, includeContext: URI): Pair<List<URL>, List<String>>
 }
 
+/**
+ * Includes a single file. The target can be a relative or absolute file path, or an HTTP URL
+ */
+private class IncludeDirective : Includable("//INCLUDE ", "@file:Include(") {
+    override fun handleTarget(include: String, includeContext: URI): Pair<List<URL>, List<String>> {
+        val includeURL = when {
+            isUrl(include)          -> URL(include)
+            include.startsWith("/") -> File(include).toURI().toURL()
+            else                    -> includeContext.resolve(URI(include.removePrefix("./"))).toURL()
+        }
+
+        try {
+            return Pair(listOf(includeURL), includeURL.readText().lines())
+        }
+        catch (e: FileNotFoundException) {
+            errorMsg("Failed to resolve $commentPrefix'${include}'")
+            System.err.println(e.message?.lines()!!.map { it.prependIndent("[kscript] [ERROR] ") })
+            quit(1)
+        }
+    }
+
+    fun isUrl(s: String) = s.startsWith("http://") || s.startsWith("https://")
+}
+
+/**
+ * Includes all files in a local directory, by replacing the INCLUDE_DIR directive with INCLUDE directives for each file
+ * in the target directory. Target must be a relative or absolute file path to a directory. Included files are sorted by
+ * absolute path and included in that order.
+ */
+private class IncludeDirDirective : Includable("//INCLUDE_DIR ", "@file:IncludeDir(") {
+    override fun handleTarget(include: String, includeContext: URI): Pair<List<URL>, List<String>> {
+        val includeURL = when {
+            include.startsWith("/") -> File(include).toURI().toURL()
+            else                    -> includeContext.resolve(URI(include.removePrefix("./"))).toURL()
+        }
+
+        try {
+            val dir = File(includeURL.toURI())
+            if (dir.exists() && dir.isDirectory) {
+                val files = dir.listFiles()
+                        .filter { fileInDir -> fileInDir.isFile }
+                        .sortedBy { fileInDir -> fileInDir.absolutePath }
+
+                return Pair(
+                        emptyList(),
+                        files.map { fileInDir -> "//INCLUDE ${fileInDir.absolutePath}" }
+                )
+            }
+            else {
+                errorMsg("Failed to resolve $commentPrefix'$include'")
+                System.err.println("'$include' does not exist or it is not a directory".prependIndent("[kscript] [ERROR] "))
+                quit(1)
+            }
+        }
+        catch (e: FileNotFoundException) {
+            errorMsg("Failed to resolve $commentPrefix'$include'")
+            System.err.println(e.message?.lines()!!.map { it.prependIndent("[kscript] [ERROR] ") })
+            quit(1)
+        }
+    }
+}
+
+/**
+ * Recursively includes all files in a local directory, by replacing the INCLUDE_DIRS directive with INCLUDE_DIR
+ * directives for each directory in the target directory. Target must be a relative or absolute file path to a
+ * directory. Included directories are sorted by absolute path and included in that order.
+ */
+private class IncludeDirsDirective : Includable("//INCLUDE_DIRS ", "@file:IncludeDirs(") {
+    override fun handleTarget(include: String, includeContext: URI): Pair<List<URL>, List<String>> {
+        val includeURL = when {
+            include.startsWith("/") -> File(include).toURI().toURL()
+            else                    -> includeContext.resolve(URI(include.removePrefix("./"))).toURL()
+        }
+
+        try {
+            val dir = File(includeURL.toURI())
+            if (dir.exists() && dir.isDirectory) {
+                val files = dir.walkTopDown().toSortedSet().toList()
+                        .filter { fileInDir -> fileInDir.isDirectory }
+                        .sortedBy { fileInDir -> fileInDir.absolutePath }
+
+                return Pair(
+                        emptyList(),
+                        files.map { fileInDir -> "//INCLUDE_DIR ${fileInDir.absolutePath}" }
+                )
+            }
+            else {
+                errorMsg("Failed to resolve $commentPrefix'$include'")
+                System.err.println("'$include' does not exist or it is not a directory".prependIndent("[kscript] [ERROR] "))
+                quit(1)
+            }
+        }
+        catch (e: FileNotFoundException) {
+            errorMsg("Failed to resolve $commentPrefix'$include'")
+            System.err.println(e.message?.lines()!!.map { it.prependIndent("[kscript] [ERROR] ") })
+            quit(1)
+        }
+    }
+}
 
 /**
  * Basic launcher used for testing

--- a/src/test/kotlin/Tests.kt
+++ b/src/test/kotlin/Tests.kt
@@ -168,4 +168,24 @@ class Tests {
         result.includes.filter { it.protocol == "file" }.map { File(it.toURI()).name } shouldBe List(4) { "include_${it + 1}.kt" }
         result.includes.filter { it.protocol != "file" }.size shouldBe 1
     }
+
+    @Test
+    fun test_include_dir() {
+        val file = File("test/resources/include_dir/input.kts")
+        val expected = File("test/resources/include_dir/expected.kts")
+
+        val result = resolveIncludes(file)
+
+        result.scriptFile.readText() shouldBe (expected.readText())
+    }
+
+    @Test
+    fun test_include_dirs() {
+        val file = File("test/resources/include_dirs/input.kts")
+        val expected = File("test/resources/include_dirs/expected.kts")
+
+        val result = resolveIncludes(file)
+
+        result.scriptFile.readText() shouldBe (expected.readText())
+    }
 }

--- a/test/resources/include_dir/annotation/include_1.kt
+++ b/test/resources/include_dir/annotation/include_1.kt
@@ -1,0 +1,1 @@
+fun annotation_include_1() = println("annotation_include_1")

--- a/test/resources/include_dir/annotation/include_2.kt
+++ b/test/resources/include_dir/annotation/include_2.kt
@@ -1,0 +1,1 @@
+fun annotation_include_2() = println("annotation_include_2")

--- a/test/resources/include_dir/annotation/include_3.kt
+++ b/test/resources/include_dir/annotation/include_3.kt
@@ -1,0 +1,1 @@
+fun annotation_include_3() = println("annotation_include_3")

--- a/test/resources/include_dir/annotation_dot/include_1.kt
+++ b/test/resources/include_dir/annotation_dot/include_1.kt
@@ -1,0 +1,1 @@
+fun annotation_dot_include_1() = println("annotation_dot_include_1")

--- a/test/resources/include_dir/annotation_dot/include_2.kt
+++ b/test/resources/include_dir/annotation_dot/include_2.kt
@@ -1,0 +1,1 @@
+fun annotation_dot_include_2() = println("annotation_dot_include_2")

--- a/test/resources/include_dir/annotation_dot/include_3.kt
+++ b/test/resources/include_dir/annotation_dot/include_3.kt
@@ -1,0 +1,1 @@
+fun annotation_dot_include_3() = println("annotation_dot_include_3")

--- a/test/resources/include_dir/comment/include_1.kt
+++ b/test/resources/include_dir/comment/include_1.kt
@@ -1,0 +1,1 @@
+fun comment_include_1() = println("comment_include_1")

--- a/test/resources/include_dir/comment/include_2.kt
+++ b/test/resources/include_dir/comment/include_2.kt
@@ -1,0 +1,1 @@
+fun comment_include_2() = println("comment_include_2")

--- a/test/resources/include_dir/comment/include_3.kt
+++ b/test/resources/include_dir/comment/include_3.kt
@@ -1,0 +1,1 @@
+fun comment_include_3() = println("comment_include_3")

--- a/test/resources/include_dir/comment_dot/include_1.kt
+++ b/test/resources/include_dir/comment_dot/include_1.kt
@@ -1,0 +1,1 @@
+fun comment_dot_include_1() = println("comment_dot_include_1")

--- a/test/resources/include_dir/comment_dot/include_2.kt
+++ b/test/resources/include_dir/comment_dot/include_2.kt
@@ -1,0 +1,1 @@
+fun comment_dot_include_2() = println("comment_dot_include_2")

--- a/test/resources/include_dir/comment_dot/include_3.kt
+++ b/test/resources/include_dir/comment_dot/include_3.kt
@@ -1,0 +1,1 @@
+fun comment_dot_include_3() = println("comment_dot_include_3")

--- a/test/resources/include_dir/expected.kts
+++ b/test/resources/include_dir/expected.kts
@@ -1,0 +1,31 @@
+// Let's resolve includes by directory!
+
+fun comment_include_1() = println("comment_include_1")
+fun comment_include_2() = println("comment_include_2")
+fun comment_include_3() = println("comment_include_3")
+fun comment_dot_include_1() = println("comment_dot_include_1")
+fun comment_dot_include_2() = println("comment_dot_include_2")
+fun comment_dot_include_3() = println("comment_dot_include_3")
+
+fun annotation_include_1() = println("annotation_include_1")
+fun annotation_include_2() = println("annotation_include_2")
+fun annotation_include_3() = println("annotation_include_3")
+fun annotation_dot_include_1() = println("annotation_dot_include_1")
+fun annotation_dot_include_2() = println("annotation_dot_include_2")
+fun annotation_dot_include_3() = println("annotation_dot_include_3")
+
+comment_include_1()
+comment_include_2()
+comment_include_3()
+comment_dot_include_1()
+comment_dot_include_2()
+comment_dot_include_3()
+
+annotation_include_1()
+annotation_include_2()
+annotation_include_3()
+annotation_dot_include_1()
+annotation_dot_include_2()
+annotation_dot_include_3()
+
+println("wow, so many includes")

--- a/test/resources/include_dir/input.kts
+++ b/test/resources/include_dir/input.kts
@@ -1,0 +1,23 @@
+// Let's resolve includes by directory!
+
+//INCLUDE_DIR comment
+//INCLUDE_DIR ./comment_dot
+
+@file:IncludeDir("annotation")
+@file:IncludeDir("./annotation_dot")
+
+comment_include_1()
+comment_include_2()
+comment_include_3()
+comment_dot_include_1()
+comment_dot_include_2()
+comment_dot_include_3()
+
+annotation_include_1()
+annotation_include_2()
+annotation_include_3()
+annotation_dot_include_1()
+annotation_dot_include_2()
+annotation_dot_include_3()
+
+println("wow, so many includes")

--- a/test/resources/include_dirs/annotation/include_1.kt
+++ b/test/resources/include_dirs/annotation/include_1.kt
@@ -1,0 +1,1 @@
+fun annotation_include_1() = println("annotation_include_1")

--- a/test/resources/include_dirs/annotation/inner/deep/include_3.kt
+++ b/test/resources/include_dirs/annotation/inner/deep/include_3.kt
@@ -1,0 +1,1 @@
+fun annotation_include_3() = println("annotation_include_3")

--- a/test/resources/include_dirs/annotation/inner/include_2.kt
+++ b/test/resources/include_dirs/annotation/inner/include_2.kt
@@ -1,0 +1,1 @@
+fun annotation_include_2() = println("annotation_include_2")

--- a/test/resources/include_dirs/annotation_dot/include_1.kt
+++ b/test/resources/include_dirs/annotation_dot/include_1.kt
@@ -1,0 +1,1 @@
+fun annotation_dot_include_1() = println("annotation_dot_include_1")

--- a/test/resources/include_dirs/annotation_dot/inner/deep/include_3.kt
+++ b/test/resources/include_dirs/annotation_dot/inner/deep/include_3.kt
@@ -1,0 +1,1 @@
+fun annotation_dot_include_3() = println("annotation_dot_include_3")

--- a/test/resources/include_dirs/annotation_dot/inner/include_2.kt
+++ b/test/resources/include_dirs/annotation_dot/inner/include_2.kt
@@ -1,0 +1,1 @@
+fun annotation_dot_include_2() = println("annotation_dot_include_2")

--- a/test/resources/include_dirs/comment/include_1.kt
+++ b/test/resources/include_dirs/comment/include_1.kt
@@ -1,0 +1,1 @@
+fun comment_include_1() = println("comment_include_1")

--- a/test/resources/include_dirs/comment/inner/deep/include_3.kt
+++ b/test/resources/include_dirs/comment/inner/deep/include_3.kt
@@ -1,0 +1,1 @@
+fun comment_include_3() = println("comment_include_3")

--- a/test/resources/include_dirs/comment/inner/include_2.kt
+++ b/test/resources/include_dirs/comment/inner/include_2.kt
@@ -1,0 +1,1 @@
+fun comment_include_2() = println("comment_include_2")

--- a/test/resources/include_dirs/comment_dot/include_1.kt
+++ b/test/resources/include_dirs/comment_dot/include_1.kt
@@ -1,0 +1,1 @@
+fun comment_dot_include_1() = println("comment_dot_include_1")

--- a/test/resources/include_dirs/comment_dot/inner/deep/include_3.kt
+++ b/test/resources/include_dirs/comment_dot/inner/deep/include_3.kt
@@ -1,0 +1,1 @@
+fun comment_dot_include_3() = println("comment_dot_include_3")

--- a/test/resources/include_dirs/comment_dot/inner/include_2.kt
+++ b/test/resources/include_dirs/comment_dot/inner/include_2.kt
@@ -1,0 +1,1 @@
+fun comment_dot_include_2() = println("comment_dot_include_2")

--- a/test/resources/include_dirs/expected.kts
+++ b/test/resources/include_dirs/expected.kts
@@ -1,0 +1,31 @@
+// Let's resolve includes by directory!
+
+fun comment_include_1() = println("comment_include_1")
+fun comment_include_2() = println("comment_include_2")
+fun comment_include_3() = println("comment_include_3")
+fun comment_dot_include_1() = println("comment_dot_include_1")
+fun comment_dot_include_2() = println("comment_dot_include_2")
+fun comment_dot_include_3() = println("comment_dot_include_3")
+
+fun annotation_include_1() = println("annotation_include_1")
+fun annotation_include_2() = println("annotation_include_2")
+fun annotation_include_3() = println("annotation_include_3")
+fun annotation_dot_include_1() = println("annotation_dot_include_1")
+fun annotation_dot_include_2() = println("annotation_dot_include_2")
+fun annotation_dot_include_3() = println("annotation_dot_include_3")
+
+comment_include_1()
+comment_include_2()
+comment_include_3()
+comment_dot_include_1()
+comment_dot_include_2()
+comment_dot_include_3()
+
+annotation_include_1()
+annotation_include_2()
+annotation_include_3()
+annotation_dot_include_1()
+annotation_dot_include_2()
+annotation_dot_include_3()
+
+println("wow, so many includes")

--- a/test/resources/include_dirs/input.kts
+++ b/test/resources/include_dirs/input.kts
@@ -1,0 +1,23 @@
+// Let's resolve includes by directory!
+
+//INCLUDE_DIRS comment
+//INCLUDE_DIRS ./comment_dot
+
+@file:IncludeDirs("annotation")
+@file:IncludeDirs("./annotation_dot")
+
+comment_include_1()
+comment_include_2()
+comment_include_3()
+comment_dot_include_1()
+comment_dot_include_2()
+comment_dot_include_3()
+
+annotation_include_1()
+annotation_include_2()
+annotation_include_3()
+annotation_dot_include_1()
+annotation_dot_include_2()
+annotation_dot_include_3()
+
+println("wow, so many includes")


### PR DESCRIPTION
This PR will resolve holgerbrandl/kscript#99, adding support for including multiple files in a local directory with a single script directive.

## INCLUDE_DIR

This directive finds all files in the target directory, and replaces the directive with `INCLUDE` directives for each file. This has the effect of including all files in the target directory into the calling script.

**Example**

```
//INCLUDE_DIR path
or
@file:IncludeDir(path)
```

## INCLUDE_DIRS

This directive finds all directories in the target directory, and replaces the directive with `INCLUDE_DIR` directives for each directory. This has the effect of recursively including all files in the target directory into the calling script.

**Example**

```
//INCLUDE_DIRS path
or
@file:IncludeDirs(path)
```