### PR TITLE
fix maven open version ranges

### DIFF
--- a/src/main/kotlin/kscript/app/Script.kt
+++ b/src/main/kotlin/kscript/app/Script.kt
@@ -97,7 +97,7 @@ private fun extractEntryPoint(line: String) = when {
     line.contains(ENTRY_ANNOT_PREFIX) ->
         line
             .replaceFirst(ENTRY_ANNOT_PREFIX, "")
-            .split(")")[0].trim(' ', '"')
+            .substringBeforeLast(")").trim(' ', '"')
     line.startsWith(ENTRY_COMMENT_PREFIX) ->
         line.split("[ ]+".toRegex()).last()
     else ->
@@ -158,16 +158,16 @@ internal fun extractDependencies(line: String) = when {
     line.contains(DEPS_ANNOT_PREFIX) -> line
         .replaceFirst(DEPS_ANNOT_PREFIX, "")
         .extractAnnotParams()
-//        .split(")")[0].split(",")
+//        ..substringBeforeLast(")").split(",")
 //        .map { it.trim(' ', '"') }
 
 
     line.contains(DEPSMAVEN_ANNOT_PREFIX) -> line
         .replaceFirst(DEPSMAVEN_ANNOT_PREFIX, "")
-        .split(")")[0].trim(' ', '"').let { listOf(it) }
+        .substringBeforeLast(")").trim(' ', '"').let { listOf(it) }
 
     line.startsWith(DEPS_COMMENT_PREFIX) ->
-        line.split("[ ;,]+".toRegex()).drop(1).map(String::trim)
+        line.split("[ ;]+".toRegex()).drop(1).map(String::trim)
 
     else ->
         throw IllegalArgumentException("can not extract entry point from non-directive")
@@ -195,7 +195,7 @@ fun Script.collectRepos(): List<MavenRepo> {
     // @file:MavenRepository("imagej", "http://maven.imagej.net/content/repositories/releases/")
     return lines
         .filter { it.contains(dependsOnMavenPrefix) }
-        .map { it.replaceFirst(dependsOnMavenPrefix, "").split(")")[0] }
+        .map { it.replaceFirst(dependsOnMavenPrefix, "").substringBeforeLast(")") }
         .map { it.split(",").map { it.trim(' ', '"', '(') }.let { MavenRepo(it[0], it[1]) } }
 
     // todo add credential support https://stackoverflow.com/questions/36282168/how-to-add-custom-maven-repository-to-gradle

--- a/src/main/kotlin/kscript/app/Script.kt
+++ b/src/main/kotlin/kscript/app/Script.kt
@@ -167,7 +167,7 @@ internal fun extractDependencies(line: String) = when {
         .substringBeforeLast(")").trim(' ', '"').let { listOf(it) }
 
     line.startsWith(DEPS_COMMENT_PREFIX) ->
-        line.split("[ ;]+".toRegex()).drop(1).map(String::trim)
+        line.split("[ ;,]+".toRegex()).drop(1).map(String::trim)
 
     else ->
         throw IllegalArgumentException("can not extract entry point from non-directive")

--- a/src/test/kotlin/Tests.kt
+++ b/src/test/kotlin/Tests.kt
@@ -15,7 +15,7 @@ class Tests {
     @Test
     fun directiveDependencyCollect() {
         val lines = listOf(
-            "//DEPS de.mpicbg.scicomp.joblist:joblist-kotlin:1.1, de.mpicbg.scicomp:kutils:0.7",
+            "//DEPS de.mpicbg.scicomp.joblist:joblist-kotlin:1.1; de.mpicbg.scicomp:kutils:0.7",
             "//DEPS  log4j:log4j:1.2.14"
         )
 
@@ -30,7 +30,7 @@ class Tests {
 
     @Test
     fun parseAnnotDependencies() {
-        val lines = listOf("""@file:DependsOn("something:dev-1.1.0-alpha3(T2):1.2.14", "de.mpicbg.scicomp:kutils:0.7")""")
+        val lines = listOf("""@file:DependsOn("something:dev-1.1.0-alpha3(T2):1.2.14"; "de.mpicbg.scicomp:kutils:0.7")""")
 
         val expected = listOf(
             "something:dev-1.1.0-alpha3(T2):1.2.14",
@@ -83,7 +83,7 @@ class Tests {
     @Test
     fun mixedDependencyCollect() {
         val lines = listOf(
-            "//DEPS de.mpicbg.scicomp.joblist:joblist-kotlin:1.1, de.mpicbg.scicomp:kutils:0.7",
+            "//DEPS de.mpicbg.scicomp.joblist:joblist-kotlin:1.1; de.mpicbg.scicomp:kutils:0.7",
             """@file:DependsOn("log4j:log4j:1.2.14")"""
         )
 

--- a/src/test/kotlin/Tests.kt
+++ b/src/test/kotlin/Tests.kt
@@ -15,7 +15,7 @@ class Tests {
     @Test
     fun directiveDependencyCollect() {
         val lines = listOf(
-            "//DEPS de.mpicbg.scicomp.joblist:joblist-kotlin:1.1; de.mpicbg.scicomp:kutils:0.7",
+            "//DEPS de.mpicbg.scicomp.joblist:joblist-kotlin:1.1, de.mpicbg.scicomp:kutils:0.7",
             "//DEPS  log4j:log4j:1.2.14"
         )
 
@@ -30,7 +30,7 @@ class Tests {
 
     @Test
     fun parseAnnotDependencies() {
-        val lines = listOf("""@file:DependsOn("something:dev-1.1.0-alpha3(T2):1.2.14"; "de.mpicbg.scicomp:kutils:0.7")""")
+        val lines = listOf("""@file:DependsOn("something:dev-1.1.0-alpha3(T2):1.2.14", "de.mpicbg.scicomp:kutils:0.7")""")
 
         val expected = listOf(
             "something:dev-1.1.0-alpha3(T2):1.2.14",
@@ -83,7 +83,7 @@ class Tests {
     @Test
     fun mixedDependencyCollect() {
         val lines = listOf(
-            "//DEPS de.mpicbg.scicomp.joblist:joblist-kotlin:1.1; de.mpicbg.scicomp:kutils:0.7",
+            "//DEPS de.mpicbg.scicomp.joblist:joblist-kotlin:1.1, de.mpicbg.scicomp:kutils:0.7",
             """@file:DependsOn("log4j:log4j:1.2.14")"""
         )
 


### PR DESCRIPTION
specifying `[1.0)` as version was broken, because kscript would not pass the correct values to the POM

disallow `,` in DEPS_COMMENT
`;` and space should still work

improve parsing of DEPS_ANNOT
use `.substringBeforeLast(")")`instead of `.split(")")[0]`
assume there is no more `)` after the annotation
maybe also make sure `//.+` is stripped before?

is there no smarter annotation parser available ?

fixes #166 