### PR TITLE
support dynamic versions ending with `+` 

### DIFF
--- a/src/main/kotlin/kscript/app/DependencyUtil.kt
+++ b/src/main/kotlin/kscript/app/DependencyUtil.kt
@@ -117,11 +117,20 @@ internal fun buildPom(depIds: List<String>, customRepos: List<MavenRepo>): Strin
             quit(1)
         }
 
+        // replace + with open version range for maven
+        val version = matchResult.groupValues[3].let {
+            if(it.endsWith("+")) {
+                "[${it.dropLast(1)},)"
+            } else {
+                it
+            }
+        }
+
         """
     <dependency>
             <groupId>${matchResult.groupValues[1]}</groupId>
             <artifactId>${matchResult.groupValues[2]}</artifactId>
-            <version>${matchResult.groupValues[3]}</version>
+            <version>$version</version>
             ${matchResult.groups[5]?.let { "<classifier>" + it.value + "</classifier>" } ?: ""}
             ${matchResult.groups[7]?.let { "<type>" + it.value + "</type>" } ?: ""}
     </dependency>

--- a/src/main/kotlin/kscript/app/Script.kt
+++ b/src/main/kotlin/kscript/app/Script.kt
@@ -97,7 +97,7 @@ private fun extractEntryPoint(line: String) = when {
     line.contains(ENTRY_ANNOT_PREFIX) ->
         line
             .replaceFirst(ENTRY_ANNOT_PREFIX, "")
-            .split(")")[0].trim(' ', '"')
+            .substringBeforeLast(")").trim(' ', '"')
     line.startsWith(ENTRY_COMMENT_PREFIX) ->
         line.split("[ ]+".toRegex()).last()
     else ->
@@ -158,13 +158,13 @@ internal fun extractDependencies(line: String) = when {
     line.contains(DEPS_ANNOT_PREFIX) -> line
         .replaceFirst(DEPS_ANNOT_PREFIX, "")
         .extractAnnotParams()
-//        .split(")")[0].split(",")
+//        ..substringBeforeLast(")").split(",")
 //        .map { it.trim(' ', '"') }
 
 
     line.contains(DEPSMAVEN_ANNOT_PREFIX) -> line
         .replaceFirst(DEPSMAVEN_ANNOT_PREFIX, "")
-        .split(")")[0].trim(' ', '"').let { listOf(it) }
+        .substringBeforeLast(")").trim(' ', '"').let { listOf(it) }
 
     line.startsWith(DEPS_COMMENT_PREFIX) ->
         line.split("[ ;,]+".toRegex()).drop(1).map(String::trim)
@@ -195,7 +195,7 @@ fun Script.collectRepos(): List<MavenRepo> {
     // @file:MavenRepository("imagej", "http://maven.imagej.net/content/repositories/releases/")
     return lines
         .filter { it.contains(dependsOnMavenPrefix) }
-        .map { it.replaceFirst(dependsOnMavenPrefix, "").split(")")[0] }
+        .map { it.replaceFirst(dependsOnMavenPrefix, "").substringBeforeLast(")") }
         .map { it.split(",").map { it.trim(' ', '"', '(') }.let { MavenRepo(it[0], it[1]) } }
 
     // todo add credential support https://stackoverflow.com/questions/36282168/how-to-add-custom-maven-repository-to-gradle

--- a/src/test/kotlin/Tests.kt
+++ b/src/test/kotlin/Tests.kt
@@ -49,7 +49,7 @@ class Tests {
 
     @Test
     fun parseAnnotWithTypeAndClassifier() {
-        val pom = buildPom(listOf("org.javamoney:moneta:1.3", "org.javamoney:moneta:1.3:pom", "org.javamoney:moneta:1.3@pom"), emptyList())
+        val pom = buildPom(listOf("org.javamoney:moneta:1.3", "org.javamoney:moneta:1.3:pom", "org.javamoney:moneta:1.3@pom", "org.javamoney:moneta:1.3+"), emptyList())
 
         val expected = "" +
                 "    <dependency>\n" +
@@ -77,6 +77,15 @@ class Tests {
                 "            \n" +
                 "            <type>pom</type>\n" +
                 "    </dependency>"
+                "    \n" +
+                "\n" +
+                "    <dependency>\n" +
+                "            <groupId>org.javamoney</groupId>\n" +
+                "            <artifactId>moneta</artifactId>\n" +
+                "            <version>[1.3,)</version>\n" +
+                "            \n" +
+                "            \n" +
+                "    </dependency>\n" +
         assertTrue(pom.contains(expected))
     }
 

--- a/test/resources/depends_on_dynamic.kts
+++ b/test/resources/depends_on_dynamic.kts
@@ -1,0 +1,18 @@
+#!/usr/bin/env kscript
+
+
+@file:DependsOn("log4j:log4j:1.2+")
+//DEPS com.offbytwo:docopt:0.6.0.+
+// neither should having comments after declartions
+
+// some pointless comment
+
+import org.docopt.Docopt
+
+// test the docopt dependency
+val docopt = Docopt("Usage: jl <command> [options] [<joblist_file>]")
+
+// instantiate a logger to test the log4j dependency
+org.apache.log4j.Logger.getRootLogger()
+
+println("dynamic kscript rocks!")

--- a/test/test_suite.sh
+++ b/test/test_suite.sh
@@ -152,6 +152,9 @@ assert "kscript ${KSCRIPT_HOME}/test/resources/depends_on_annot.kts" "kscript wi
 # make sure that @file:DependsOnMaven is parsed correctly
 assert "kscript ${KSCRIPT_HOME}/test/resources/depends_on_maven_annot.kts" "kscript with annotations rocks!"
 
+# make sure that dynamic versions are matched properly
+assert "kscript ${KSCRIPT_HOME}/test/resources/depends_on_dynamic.kts" "dynamic kscript rocks!"
+
 # make sure that @file:MavenRepository is parsed correctly
 assert "kscript ${KSCRIPT_HOME}/test/resources/custom_mvn_repo_annot.kts" "kscript with annotations rocks!"
 


### PR DESCRIPTION
for maven these are wrappend in a range
`1.2.3+` -> `[1.2.3,)`

for gradle they are not touched and just passed as is

closes #166 