### PR TITLE
cygwin support improvements

### DIFF
--- a/src/main/kotlin/kscript/app/AppHelpers.kt
+++ b/src/main/kotlin/kscript/app/AppHelpers.kt
@@ -244,7 +244,7 @@ sourceSets.main.java.srcDirs 'src'
         // also symlink all includes
         includeURLs.distinctBy { it.fileName() }
           .forEach {
-            
+
             val includeFile = when {
                 it.protocol == "file" -> File(it.toURI())
                 else -> fetchFromURL(it.toString())
@@ -254,7 +254,7 @@ sourceSets.main.java.srcDirs 'src'
         }
     }
 
-    return "idea ${tmpProjectDir.absolutePath}"
+    return "idea \"${tmpProjectDir.absolutePath}\""
 }
 
 private fun URL.fileName() = this.toURI().path.split("/").last()
@@ -313,7 +313,7 @@ $stringifiedDeps
     compile group: 'org.jetbrains.kotlin', name: 'kotlin-script-runtime', version: '${KotlinVersion.CURRENT}'
 
     // https://stackoverflow.com/questions/20700053/how-to-add-local-jar-file-dependency-to-build-gradle-file
-    compile files('${scriptJar}')
+    compile files('${scriptJar.invariantSeparatorsPath}')
 }
 
 // http://www.capsule.io/user-guide/#really-executable-capsules
@@ -360,11 +360,14 @@ exec java -jar ${'$'}0 "${'$'}@"
 
     File(tmpProjectDir, "build.gradle").writeText(gradleScript)
 
-    val pckgResult = evalBash("cd ${tmpProjectDir} && gradle simpleCapsule && cp build/libs/${appName}*.jar ${pckgedJar} && chmod +x ${pckgedJar}")
+    val pckgResult = evalBash("cd '${tmpProjectDir}' && gradle simpleCapsule")
 
     with(pckgResult) {
         kscript.app.errorIf(exitCode != 0) { "packaging of '$appName' failed:\n$pckgResult" }
     }
+
+    pckgedJar.delete()
+    File(tmpProjectDir, "build/libs/${appName}-capsule.jar").copyTo(pckgedJar, true)
 
     infoMsg("Finished packaging into ${pckgedJar}")
 }

--- a/src/main/kotlin/kscript/app/AppHelpers.kt
+++ b/src/main/kotlin/kscript/app/AppHelpers.kt
@@ -316,28 +316,11 @@ $stringifiedDeps
     compile files('${scriptJar.invariantSeparatorsPath}')
 }
 
-// http://www.capsule.io/user-guide/#really-executable-capsules
-def reallyExecutable(jar) {
-    ant.concat(destfile: "tmp.jar", binary: true) {
-        //zipentry(zipfile: configurations.capsule.singleFile, name: 'capsule/execheader.sh')
-        fileset(dir: '.', includes: 'exec_header.sh')
-
-        fileset(dir: jar.destinationDir) {
-            include(name: jar.archiveName)
-        }
-    }
-    copy {
-        from 'tmp.jar'
-        into jar.destinationDir
-        rename { jar.archiveName }
-    }
-    delete 'tmp.jar'
-}
-
 task simpleCapsule(type: FatCapsule){
   applicationClass '$wrapperClassName'
 
-  baseName '$appName'
+  archiveName '$appName'
+  reallyExecutable
 
   capsuleManifest {
     jvmArgs = [$jvmOptions]
@@ -345,8 +328,6 @@ task simpleCapsule(type: FatCapsule){
     //systemProperties['java.awt.headless'] = true
   }
 }
-
-simpleCapsule.doLast { task -> reallyExecutable(task) }
     """.trimIndent()
 
     val pckgedJar = File(Paths.get("").toAbsolutePath().toFile(), appName).absoluteFile
@@ -367,7 +348,7 @@ exec java -jar ${'$'}0 "${'$'}@"
     }
 
     pckgedJar.delete()
-    File(tmpProjectDir, "build/libs/${appName}-capsule.jar").copyTo(pckgedJar, true)
+    File(tmpProjectDir, "build/libs/${appName}").copyTo(pckgedJar, true)
 
     infoMsg("Finished packaging into ${pckgedJar}")
 }

--- a/src/main/kotlin/kscript/app/Kscript.kt
+++ b/src/main/kotlin/kscript/app/Kscript.kt
@@ -270,7 +270,7 @@ fun main(args: Array<String>) {
     if (classpath.isNotEmpty())
         extClassPath += kscript.app.CP_SEPARATOR_CHAR + classpath
 
-    println("kotlin ${kotlinOpts} -classpath ${extClassPath} ${execClassName} ${joinedUserArgs} ")
+    println("kotlin ${kotlinOpts} -classpath \"${extClassPath}\" ${execClassName} ${joinedUserArgs} ")
 }
 
 


### PR DESCRIPTION
Currently kscript is not working on Windows in cygwin.

> /cygdrive/c/kotlin/scripting
$ kscript 'println("hello world")'
error: please specify at least one name or file to run

Most of the issues were caused by not quoting paths containing windows path separator '\' that was actually escaping characters in cygwin.

The '--package' didn't work for similar reason. In the generated gradle build file the actual script was added with windows path separators '\'. Now using invariant separator '/'.