### PR TITLE
Support "~" in INCLUDE

### DIFF
--- a/src/main/kotlin/kscript/app/ResolveIncludes.kt
+++ b/src/main/kotlin/kscript/app/ResolveIncludes.kt
@@ -35,6 +35,7 @@ fun resolveIncludes(template: File, includeContext: URI = template.parentFile.to
                 val includeURL = when {
                     isUrl(include) -> URL(include)
                     include.startsWith("/") -> File(include).toURI().toURL()
+                    include.startsWith("~/") -> File(System.getenv("HOME")!! + include.substring(1)).toURI().toURL()
                     else -> includeContext.resolve(URI(include.removePrefix("./"))).toURL()
                 }
 


### PR DESCRIPTION
Hi,

This change enables to include files relative to home directory like below:

@file:Include("~/my-kscript/utils.kt")

