### PR TITLE
Don't hardcode the KSCRIPT_HOME path in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ install:
   - sdk install kotlin
   - sdk install gradle
 
-  - export KSCRIPT_HOME="/home/travis/build/holgerbrandl/kscript"
+  - export KSCRIPT_HOME=${TRAVIS_BUILD_DIR}
   - export PATH=${KSCRIPT_HOME}/build/libs:$PATH
 
   # build it


### PR DESCRIPTION
This makes it so tests can pass on forks too if contributors enable them in Travis.