### PR TITLE
Fix cache check bug on Windows

### DIFF
--- a/src/main/kotlin/kscript/app/DependencyUtil.kt
+++ b/src/main/kotlin/kscript/app/DependencyUtil.kt
@@ -36,7 +36,7 @@ fun resolveDependencies(depIds: List<String>, customRepos: List<MavenRepo> = emp
 
 
             // Make sure that local dependencies have not been wiped since resolving them (like by deleting .m2) (see #146)
-            if (cachedCP.split(":").all { File(it).exists() }) {
+            if (cachedCP.split(CP_SEPARATOR_CHAR).all { File(it).exists() }) {
                 return cachedCP
             } else {
                 System.err.println("[kscript] Detected missing dependencies in cache.")


### PR DESCRIPTION
This is a simple bug fix PR. After aether change, kscript does dependency resolution repeatedly on Windows.
