### PR TITLE
Reuse JVM

### DIFF
--- a/src/kscript
+++ b/src/kscript
@@ -22,13 +22,57 @@ abs_kscript_path=$(resolve_symlink $(absolute_path $0))
 
 ## resolve application jar path from script location and convert to windows path when using cygwin
 jarPath=$(dirname $abs_kscript_path)/kscript.jar
-if [[ $(uname) == CYGWIN* ]]; then jarPath=$(cygpath -w ${jarPath}); fi
 
 ## prefer KOTLIN_HOME instead of PATH to resolve `kotlin` location (see #145)
 if [[ -z "$KOTLIN_HOME" ]]; then KOTLIN_EXEC="kotlin"; else KOTLIN_EXEC="$KOTLIN_HOME/bin/kotlin"; fi
 
-## expose the name of the script being run to the script itself
-export KSCRIPT_FILE="$1"
+if [[ $(uname) == CYGWIN* ]]; then
+    jarPath=$(cygpath -w ${jarPath})
+    [[ ! -z $KOTLIN_HOME ]] && KOTLIN_HOME=$(cygpath -w ${KOTLIN_HOME})
+fi
 
-## run it using command substitution to have just the user process once kscript is done
-eval "exec $(${KOTLIN_EXEC} -classpath ${jarPath} kscript.app.KscriptKt "$@")"
+## -J -D (borrowed from 'kotlinc')
+
+declare -a java_args
+declare -a kscript_args
+
+export KSCRIPT_FILE=
+
+while [ $# -gt 0 ]; do
+    is_java_arg=
+    case "$1" in
+	-D*)
+            [[ -z $KSCRIPT_FILE ]] && is_java_arg=1
+            ;;
+	-J*)
+            [[ -z $KSCRIPT_FILE ]] && is_java_arg=1
+            ;;
+	*)
+            if [[ ! $1 =~ ^-. ]]; then
+		export KSCRIPT_FILE=$1
+	    fi
+            ;;
+    esac
+    if [[ -n $is_java_arg ]]; then
+       java_args=("${java_args[@]}" "$1")
+    else
+	kscript_args=("${kscript_args[@]}" "$1")
+    fi
+    shift
+done
+
+## KotlinOpts 
+
+if [[ -r $KSCRIPT_FILE ]]; then
+    commentOpts=(`grep '^//KOTLIN_OPTS ' $KSCRIPT_FILE | sed 's/^\/\/KOTLIN_OPTS \(.*\)/\1/'`)
+    if [[ -n $commentOpts ]]; then
+	java_args=("${java_args[@]}" "${commentOpts[@]}")
+    fi
+    fileOpts=(`grep '^@file:KotlinOpts(' $KSCRIPT_FILE | sed 's/.*"\(.*\)".*/\1/'`)
+    if [[ -n $fileOpts ]]; then
+	java_args=("${java_args[@]}" "${fileOpts[@]}")
+    fi
+fi
+
+## run it
+exec ${KOTLIN_EXEC} "${java_args[@]}" -classpath ${jarPath} kscript.app.KscriptKt "${kscript_args[@]}"

--- a/src/main/kotlin/kscript/app/DependencyUtil.kt
+++ b/src/main/kotlin/kscript/app/DependencyUtil.kt
@@ -11,7 +11,7 @@ import java.io.File
 
 val DEP_LOOKUP_CACHE_FILE = File(KSCRIPT_CACHE_DIR, "dependency_cache.txt")
 
-val CP_SEPARATOR_CHAR = if (System.getProperty("os.name").toLowerCase().contains("windows")) ";" else ":"
+val CP_SEPARATOR_CHAR = if (IS_WINDOWS) ";" else ":"
 
 
 fun resolveDependencies(depIds: List<String>, customRepos: List<MavenRepo> = emptyList(), loggingEnabled: Boolean): String? {

--- a/src/main/kotlin/kscript/app/JarFileLoader.kt
+++ b/src/main/kotlin/kscript/app/JarFileLoader.kt
@@ -1,0 +1,14 @@
+package kscript.app
+
+import java.io.File
+import java.net.URL
+import java.net.URLClassLoader
+
+// https://dzone.com/articles/add-jar-file-java-load-path
+
+class JarFileLoader(urls: Array<URL> = arrayOf()) : URLClassLoader(urls) {
+    fun addFile(file: File) {
+        addURL(file.toURI().toURL())
+    }
+}
+

--- a/src/main/kotlin/kscript/app/KotlinRunner.kt
+++ b/src/main/kotlin/kscript/app/KotlinRunner.kt
@@ -1,0 +1,61 @@
+package kscript.app
+
+import java.io.File
+
+class KotlinRunner(private val kotlinHome: String) {
+    companion object {
+        private const val PRELOADER_CLASS = "org.jetbrains.kotlin.preloading.Preloader"
+        private const val RUNNER_MAIN_CLASS = "org.jetbrains.kotlin.runner.Main"
+    }
+
+    private val jarFileLoader by lazy { JarFileLoader() }
+
+    private val compilerBaseArgs = listOf("-cp", joinToPathString(kotlinHome, "lib", "kotlin-compiler.jar"),
+            "org.jetbrains.kotlin.cli.jvm.K2JVMCompiler")
+
+    private val preloaderMainMethod by lazy {
+        val preloaderJar = File(joinToPathString(kotlinHome, "lib", "kotlin-preloader.jar"))
+        jarFileLoader.addFile(preloaderJar)
+        jarFileLoader.loadClass(PRELOADER_CLASS).getDeclaredMethod("main", Array<String>::class.java)
+    }
+    private val runnerMainMethod by lazy {
+        System.getProperties().setProperty("kotlin.home", kotlinHome)
+        jarFileLoader.addFile(File(joinToPathString(kotlinHome, "lib", "kotlin-runner.jar")))
+        jarFileLoader.loadClass(RUNNER_MAIN_CLASS).getDeclaredMethod("main", Array<String>::class.java)
+    }
+
+    fun compile(compilerOpts: List<String>, targetJarFile: File, sourceFiles: List<File>, classpath: String?) {
+        val baseArgs = listOf("-Xskip-runtime-version-check") +
+                compilerOpts + listOf("-d", targetJarFile.absolutePath)
+        val cpArgs = classPathArgs(classpath)
+        runKotlinc(baseArgs + sourceFiles.map { it.absolutePath } + cpArgs)
+    }
+
+    fun runScript(scriptClassPath: String, execClassName: String, userArgs: List<String>): Int {
+        val runnerArgs = listOf("-cp", scriptClassPath, execClassName) + userArgs
+        runKotlin(runnerArgs)
+        return 0
+    }
+
+    fun interactiveShell(jarFile: File, classpath: String?, compilerOpts: List<String>) {
+        val jarPath = if (jarFile.isFile) jarFile.absolutePath else null
+        val args = compilerOpts + classPathArgs(classpath, jarPath)
+        runKotlinc(args)
+    }
+
+    private fun classPathArgs(vararg paths: String?): List<String> {
+        val combinedClasspath = listOfNotNull(*paths).filter { it.isNotEmpty() }.joinToString(CP_SEPARATOR_CHAR)
+        return if (combinedClasspath.isNotEmpty()) {
+            listOf("-cp", combinedClasspath)
+        } else listOf()
+    }
+
+    private fun runKotlinc(args: Collection<String>) {
+        preloaderMainMethod.invoke(jarFileLoader, (compilerBaseArgs + args).toTypedArray())
+    }
+
+    private fun runKotlin(args: Collection<String>) {
+        runnerMainMethod.invoke(jarFileLoader, args.toTypedArray())
+    }
+}
+

--- a/test/resources/kotlin_opts_test.kts
+++ b/test/resources/kotlin_opts_test.kts
@@ -1,0 +1,7 @@
+@file:KotlinOpts("-J-Xmx5g   -Dkscript.opt1=1")
+//KOTLIN_OPTS  -Dkscript.opt2=foo   -Dkscript.opt3=bar
+
+// https://stackoverflow.com/questions/7611987/how-to-check-the-configured-xmx-value-for-a-running-java-application
+
+//println("arg is " + args[0])
+println("mem_${Runtime.getRuntime().maxMemory()}_${System.getProperty("kscript.opt1")}_${System.getProperty("kscript.opt2")}_${System.getProperty("kscript.opt3")}")

--- a/test/test_suite.sh
+++ b/test/test_suite.sh
@@ -260,6 +260,8 @@ assert "source ${KSCRIPT_HOME}/test/resources/home_dir_include.sh" "42"
 ## prevent regression of #173
 assert "source ${KSCRIPT_HOME}/test/resources/compiler_opts_with_includes.sh" "hello42"
 
+## KOTLIN_OPTS
+assert "kscript ${KSCRIPT_HOME}/test/resources/kotlin_opts_test.kts" "mem_4772593664_1_foo_bar"
 
 kscript_nocall() { kotlin -classpath ${KSCRIPT_HOME}/build/libs/kscript.jar kscript.app.KscriptKt "$@";}
 export -f kscript_nocall

--- a/test/test_suite.sh
+++ b/test/test_suite.sh
@@ -263,6 +263,10 @@ assert "source ${KSCRIPT_HOME}/test/resources/compiler_opts_with_includes.sh" "h
 ## KOTLIN_OPTS
 assert "kscript ${KSCRIPT_HOME}/test/resources/kotlin_opts_test.kts" "mem_4772593664_1_foo_bar"
 
+## kscript.jar class access test
+assert_raises 'kscript "println(org.docopt.Docopt::class)"' 1
+
+
 kscript_nocall() { kotlin -classpath ${KSCRIPT_HOME}/build/libs/kscript.jar kscript.app.KscriptKt "$@";}
 export -f kscript_nocall
 

--- a/test/test_suite.sh
+++ b/test/test_suite.sh
@@ -133,10 +133,10 @@ export -f resolve_deps
 assert_stderr "resolve_deps log4j:log4j:1.2.14" "${HOME}/.m2/repository/log4j/log4j/1.2.14/log4j-1.2.14.jar"
 
 ## impossible version
-assert "resolve_deps log4j:log4j:9.8.76" "false"
+assert_raises "resolve_deps log4j:log4j:9.8.76" 1
 
 ## wrong format should exit with 1
-assert "resolve_deps log4j:1.0" "false"
+assert_raises "resolve_deps log4j:1.0" 1
 
 assert_stderr "resolve_deps log4j:1.0" "[ERROR] Invalid dependency locator: 'log4j:1.0'.  Expected format is groupId:artifactId:version[:classifier][@type]"
 
@@ -267,14 +267,17 @@ assert "kscript ${KSCRIPT_HOME}/test/resources/kotlin_opts_test.kts" "mem_477259
 assert_raises 'kscript "println(org.docopt.Docopt::class)"' 1
 
 
-kscript_nocall() { kotlin -classpath ${KSCRIPT_HOME}/build/libs/kscript.jar kscript.app.KscriptKt "$@";}
-export -f kscript_nocall
+##
+## --idea tests were commented out as they do not make sense anymore
 
-## temp projects with include symlinks
-assert_raises 'tmpDir=$(kscript_nocall --idea test/resources/includes/include_variations.kts | cut -f2 -d" " | xargs echo); cd $tmpDir && gradle build' 0
+# kscript_nocall() { kotlin -classpath ${KSCRIPT_HOME}/build/libs/kscript.jar kscript.app.KscriptKt "$@";}
+# export -f kscript_nocall
 
-## support diamond-shaped include schemes (see #133)
-assert_raises 'tmpDir=$(kscript_nocall --idea test/resources/includes/diamond.kts | cut -f2 -d" " | xargs echo); cd $tmpDir && gradle build' 0
+# ## temp projects with include symlinks
+# assert_raises 'tmpDir=$(kscript_nocall --idea test/resources/includes/include_variations.kts | cut -f2 -d" " | xargs echo); cd $tmpDir && gradle build' 0
+
+# ## support diamond-shaped include schemes (see #133)
+# assert_raises 'tmpDir=$(kscript_nocall --idea test/resources/includes/diamond.kts | cut -f2 -d" " | xargs echo); cd $tmpDir && gradle build' 0
 
 ## todo reenable interactive mode tests using kscript_nocall
 


### PR DESCRIPTION
As discussed on #102, this PR processes KOTLIN_OPTS in kscript bash.

The kotlin code differences between #102 and this are:
- It is one commit 
- KOTLIN_OPTS processing code has been removed, and it is lazy operation for --package

Now, scripts using KOTLIN_OPTS can enjoy the startup time improvement by reusing the JVM at the expense of complex kscript bash script.
