### PR TITLE
Compile native version using graal, reducing startup time to almost 0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,12 +3,23 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 plugins {
     kotlin("jvm") version "1.2.70"
     id("com.github.johnrengelman.shadow") version "2.0.4"
+    id("com.palantir.graal") version "0.2.0-17-g543ec9e"
+}
+
+graal {
+    graalVersion("1.0.0-rc10")
+    mainClass("kscript.app.KscriptKt")
+    outputName("kscript-native")
+    option("--report-unsupported-elements-at-runtime")
+    // Avoids a nasty nondeterministic error in graal: https://github.com/oracle/graal/issues/908
+    option("-H:-UseServiceLoaderFeature")
 }
 
 group = "com.github.holgerbrandl.kscript.launcher"
 
 dependencies {
     compileOnly("org.jetbrains.kotlin:kotlin-stdlib")
+    compile("org.jetbrains.kotlin:kotlin-reflect")
 
     compile("com.offbytwo:docopt:0.6.0.20150202")
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Without this, `kscript --help` takes 0.6 to 0.9 seconds.
With this, it takes 0.02 seconds 🎉 

This still needs to be integrated into the release script, but for now you can use it by running `./gradlew nativeImage`, then using the binary at `./build/graal/kscript-native`.