### PR TITLE
Fix package path on text processing mode doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ Text Processing Mode
 
 * Declare `com.github.holgerbrandl:kscript-support:1.2.4` as dependency for the script. This [support library](https://github.com/holgerbrandl/kscript-support-api) eases the writing of Kotlin scriptlets for text-processing. It includes solutions to common use-cases like argument parsing, data streaming, IO utilities, and various iterators to streamline the writing of scriptlets for text processing.
 * Import the `kscript.*` namespace
-* Define variable `val lines = kscript.text.StreamUtilKt.resolveArgFile(args)` which returns an iterator over the lines in the first input argument of the script, or the standard input if no file arguments are provided to the script
+* Define variable `val lines = kscript.text.resolveArgFile(args)` which returns an iterator over the lines in the first input argument of the script, or the standard input if no file arguments are provided to the script
 
 
 This allows to to replace `awk`ward constructs (or `sed` or`perl`) with _kotlinesque_ solutions such as


### PR DESCRIPTION
I believe it should be `kscript.text.resolveArgFile(args)` instead of `kscript.text.StreamUtilKt.resolveArgFile(args)` ?