### PR TITLE
Make INCLUDE directive files relative to script dir

### DIFF
--- a/src/main/kotlin/kscript/app/Kscript.kt
+++ b/src/main/kotlin/kscript/app/Kscript.kt
@@ -333,6 +333,7 @@ fun prepareScript(scriptResource: String): Pair<File, URI> {
             // if we can "just" read from script resource create tmp file
             // i.e. script input is process substitution file handle
             // not FileInputStream(this).bufferedReader().use{ readText()} does not work nor does this.readText
+            includeContext = this.absoluteFile.parentFile.toURI()
             createTmpScript(FileInputStream(this).bufferedReader().readText())
         }
     }

--- a/test/resources/includes/shebang_mode_includes
+++ b/test/resources/includes/shebang_mode_includes
@@ -1,0 +1,4 @@
+#!/usr/bin/env kscript
+
+//INCLUDE rel_includes/include_1.kt
+include_1()

--- a/test/test_suite.sh
+++ b/test/test_suite.sh
@@ -267,6 +267,9 @@ export -f kscript_nocall
 ## temp projects with include symlinks
 assert_raises 'tmpDir=$(kscript_nocall --idea test/resources/includes/include_variations.kts | cut -f2 -d" " | xargs echo); cd $tmpDir && gradle build' 0
 
+## Ensure relative includes with in shebang mode
+assert_raises resources/includes/shebang_mode_includes 0
+
 ## support diamond-shaped include schemes (see #133)
 assert_raises 'tmpDir=$(kscript_nocall --idea test/resources/includes/diamond.kts | cut -f2 -d" " | xargs echo); cd $tmpDir && gradle build' 0
 


### PR DESCRIPTION
The documentation is a bit unclear on what the INCLUDE directive paths are supposed to be relative to - the workdir or script dir? This change makes them relative to the script dir, so that scripts can be invoked from any workdir.

**Old behavior:**

Main script file: "my-script":
```
#!/usr/bin/env kscript

//INCLUDE src/helpers.kt
doIt();
```
Support file: "src/helpers.kt":

```
fun doIt() {
    println("Do something")
}
```

This works: `$ ./my-script`
This fails: `$ cd src/; ../my-script`
[kscript] [ERROR] Failed to resolve //INCLUDE 'src/helpers.kt'

**New behavior:**
This works: `$ ./my-script`
This works: `$ cd src/; ../my-script`
