### PR TITLE
Add support for trailing logic after @file:Include

### DIFF
--- a/src/main/kotlin/kscript/app/ResolveIncludes.kt
+++ b/src/main/kotlin/kscript/app/ResolveIncludes.kt
@@ -77,7 +77,7 @@ internal fun extractIncludeTarget(incDirective: String): Pair<String, String?> {
         incDirective.startsWith(INCLUDE_ANNOT_PREFIX) -> {
             with(incDirective.replaceFirst(INCLUDE_ANNOT_PREFIX, "").split(")", ");", limit = 2)) {
                 // TODO: Once on Kotlin 1.3, the following conditional can become `this[1].ifBlank { null }`
-                Pair(this[0].trim(' ', '"'), if (this[1].isNotBlank()) this[1] else null)
+                Pair(this[0].trim(' ', '"'), this[1].takeIf { it.isNotBlank() })
             }
         }
         // Comment directives cannot have trailing logic (as it would still be within a comment)

--- a/src/main/kotlin/kscript/app/ResolveIncludes.kt
+++ b/src/main/kotlin/kscript/app/ResolveIncludes.kt
@@ -76,7 +76,6 @@ internal fun extractIncludeTarget(incDirective: String): Pair<String, String?> {
     return when {
         incDirective.startsWith(INCLUDE_ANNOT_PREFIX) -> {
             with(incDirective.replaceFirst(INCLUDE_ANNOT_PREFIX, "").split(")", ");", limit = 2)) {
-                // TODO: Once on Kotlin 1.3, the following conditional can become `this[1].ifBlank { null }`
                 Pair(this[0].trim(' ', '"'), this[1].takeIf { it.isNotBlank() })
             }
         }

--- a/src/main/kotlin/kscript/app/ResolveIncludes.kt
+++ b/src/main/kotlin/kscript/app/ResolveIncludes.kt
@@ -76,7 +76,8 @@ internal fun extractIncludeTarget(incDirective: String): Pair<String, String?> {
     return when {
         incDirective.startsWith(INCLUDE_ANNOT_PREFIX) -> {
             with(incDirective.replaceFirst(INCLUDE_ANNOT_PREFIX, "").split(")", ");", limit = 2)) {
-                Pair(this[0].trim(' ', '"'), this.getOrNull(1))
+                // TODO: Once on Kotlin 1.3, the following conditional can become `this[1].ifBlank { null }`
+                Pair(this[0].trim(' ', '"'), if (this[1].isNotBlank()) this[1] else null)
             }
         }
         // Comment directives cannot have trailing logic (as it would still be within a comment)


### PR DESCRIPTION
This allows for running logic after the file include annotation.

For example: `kscript '@file:Include("file.kt"); myFunction()'`.