### PR TITLE
Fix bootstrap header

### DIFF
--- a/misc/boostrap_header.sh
+++ b/misc/boostrap_header.sh
@@ -3,12 +3,14 @@ _in_path kscript && echo "kscript is already installed at $(which kscript)" 1>&2
     function echo_and_eval() { echo "$ $@" 1>&2; eval "$@" 1>&2; }
     _in_path sdk || {
         curl "https://get.sdkman.io" | bash 1>&2 && \
-            echo_and_eval source "$"SDKMAN_DIR/bin/sdkman-init.sh
+            echo_and_eval source "$SDKMAN_DIR/bin/sdkman-init.sh"
     }
 
     sdkman_auto_answer=true
 
+    _in_path java || echo_and_eval sdk install java
     _in_path kotlin || echo_and_eval sdk install kotlin
     _in_path gradle || echo_and_eval sdk install gradle
-    echo_and_eval sdk install kscript
+    _in_path kscript || echo_and_eval sdk install kscript
+    echo_and_eval source "$SDKMAN_DIR/bin/sdkman-init.sh"
 }


### PR DESCRIPTION
Fixes #227 resolving following issues:
- Misprint in quotes mark lads to fail after installing sdkman — command resolves to `$SDKMAN_DIR/bin/sdkman-init.sh` instead of `/home/olegg/.sdkman/bin/sdkman-init.sh`
- Missing java installation routine — when running `kscript` on a fresh Ubuntu installation, script crashes with error message `/home/olegg/.sdkman/candidates/kotlin/current/bin/kotlinc: line 80: java: command not found`
- Failure on script re-run — if `sdkman` already had `kscript` installed, it was erring out instead of silently continue.
- Failure on initial install — after all required tools are installed, we should re-source sdkman, so shell will see all newly installed tools.

