### PR TITLE
add support for reading credentials from environment variables in @MavenRepository

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     compile("org.apache.maven:maven-core:3.0.3")
     compile("org.slf4j:slf4j-nop:1.7.25")
 
+    testCompile("com.github.stefanbirkner:system-rules:1.19.0")
     testCompile("junit:junit:4.12")
     testCompile( "io.kotlintest:kotlintest:2.0.7")
     testCompile(kotlin("script-runtime"))

--- a/test/test_suite.sh
+++ b/test/test_suite.sh
@@ -268,7 +268,7 @@ export -f kscript_nocall
 assert_raises 'tmpDir=$(kscript_nocall --idea test/resources/includes/include_variations.kts | cut -f2 -d" " | xargs echo); cd $tmpDir && gradle build' 0
 
 ## Ensure relative includes with in shebang mode
-assert_raises resources/includes/shebang_mode_includes 0
+assert_raises "${KSCRIPT_HOME}/test/resources/includes/shebang_mode_includes" 0
 
 ## support diamond-shaped include schemes (see #133)
 assert_raises 'tmpDir=$(kscript_nocall --idea test/resources/includes/diamond.kts | cut -f2 -d" " | xargs echo); cd $tmpDir && gradle build' 0


### PR DESCRIPTION
In #214 support for credentials in @MavenRepository was added. This PR extends that functionality to optionally provide an environment variable in stead of the value directly.

The implementation uses the `user="{{VAR}}"` syntax. It would have been nicer to support literal script calls, like `user="${System.getEnv("VAR")}"`, but this would require writing a custom templating engine (see https://stackoverflow.com/a/52183931/3968618) and compiling the code, but that is a lot of work for variable replacement and I also felt it would be risky to allow script injection here. On the other hand, using the basic form of kotlin variable syntax (e.g. "$ENV_VAR") but not any of the others (e.g. with logic in "${}") would be confusing for users.
Therefore I decided that a custom syntax would be the best option here, but I am open to feedback.