### PR TITLE
Create a default Run Configuration for Idea

### DIFF
--- a/src/main/kotlin/kscript/app/Kscript.kt
+++ b/src/main/kotlin/kscript/app/Kscript.kt
@@ -150,7 +150,7 @@ fun main(args: Array<String>) {
 
     //  Create temporary dev environment
     if (docopt.getBoolean("idea")) {
-        println(launchIdeaWithKscriptlet(rawScript, dependencies, customRepos, includeURLs))
+        println(launchIdeaWithKscriptlet(rawScript, userArgs, dependencies, customRepos, includeURLs))
         exitProcess(0)
     }
 

--- a/test/test_suite.sh
+++ b/test/test_suite.sh
@@ -268,7 +268,7 @@ export -f kscript_nocall
 assert_raises 'tmpDir=$(kscript_nocall --idea test/resources/includes/include_variations.kts | cut -f2 -d" " | xargs echo); cd $tmpDir && gradle build' 0
 
 ## Ensure relative includes with in shebang mode
-assert_raises resources/includes/shebang_mode_includes 0
+assert_raises "${KSCRIPT_HOME}/test/resources/includes/shebang_mode_includes" 0
 
 ## support diamond-shaped include schemes (see #133)
 assert_raises 'tmpDir=$(kscript_nocall --idea test/resources/includes/diamond.kts | cut -f2 -d" " | xargs echo); cd $tmpDir && gradle build' 0


### PR DESCRIPTION
Create a default Run Configuration for Intellij when using the `idea`
option. Achieved by creating a `Main` configuration within
`.idea/runConfigurations`. The `userArgs` are also passed along by
default.

Running `kscript --idea test.kts a b c` will now create a default run configuration as seen in the screenshots below.

![image](https://user-images.githubusercontent.com/1205783/66695667-45ef0100-ec79-11e9-8f46-611df66f07cc.png)

See this issue for more info: https://github.com/holgerbrandl/kscript/issues/243