### PR TITLE
Fix PKGBUIILD creation for AUR release

### DIFF
--- a/misc/kscript_release.sh
+++ b/misc/kscript_release.sh
@@ -244,7 +244,7 @@ arch=('any')
 url='https://github.com/holgerbrandl/kscript'
 license=('MIT')
 depends=('kotlin')
-source=("\${pkgname}-\${pkgver}.bin.zip::https://github.com/holgerbrandl/\${pkgname}/releases/download/v\${pkgver}/\${pkgname}-\${pkgver}-bin.zip")
+source=("\${pkgname}-\${pkgver}-bin.zip::https://github.com/holgerbrandl/\${pkgname}/releases/download/v\${pkgver}/\${pkgname}-\${pkgver}-bin.zip")
 sha256sums=('${archiveMd5}')
 
 package() {

--- a/misc/kscript_release.sh
+++ b/misc/kscript_release.sh
@@ -244,14 +244,14 @@ arch=('any')
 url='https://github.com/holgerbrandl/kscript'
 license=('MIT')
 depends=('kotlin')
-source=("${pkgname}-${pkgver}.bin.zip::https://github.com/holgerbrandl/${pkgname}/releases/download/v${pkgver}/${pkgname}-${pkgver}-bin.zip")
+source=("\${pkgname}-\${pkgver}.bin.zip::https://github.com/holgerbrandl/\${pkgname}/releases/download/v\${pkgver}/\${pkgname}-\${pkgver}-bin.zip")
 sha256sums=('${archiveMd5}')
 
 package() {
-    cd "${srcdir}/${pkgname}-${pkgver}/bin"
+    cd "\${srcdir}/\${pkgname}-\${pkgver}/bin"
 
-    install -Dm 755 kscript "${pkgdir}/usr/bin/kscript"
-    install -Dm 644 kscript.jar "${pkgdir}/usr/bin/kscript.jar"
+    install -Dm 755 kscript "\${pkgdir}/usr/bin/kscript"
+    install -Dm 644 kscript.jar "\${pkgdir}/usr/bin/kscript.jar"
 }
 
 EOF

--- a/misc/kscript_release.sh
+++ b/misc/kscript_release.sh
@@ -259,15 +259,15 @@ EOF
 #update the PKGBUILD file/pkgver variable
 cat - <<EOF > .SRCINFO
 pkgbase = kscript
-	pkgdesc = Enhanced scripting support for Kotlin on *nix-based systems
-	pkgver = ${kscript_version}
-	pkgrel = 1
-	url = https://github.com/holgerbrandl/kscript
-	arch = any
-	license = MIT
-	depends = kotlin
-	source = kscript-${kscript_version}.bin.zip::https://github.com/holgerbrandl/kscript/releases/download/v${kscript_version}/kscript-${kscript_version}-bin.zip
-	sha256sums = ${archiveMd5}
+pkgdesc = Enhanced scripting support for Kotlin on *nix-based systems
+pkgver = ${kscript_version}
+pkgrel = 1
+url = https://github.com/holgerbrandl/kscript
+arch = any
+license = MIT
+depends = kotlin
+source = kscript-${kscript_version}.bin.zip::https://github.com/holgerbrandl/kscript/releases/download/v${kscript_version}/kscript-${kscript_version}-bin.zip
+sha256sums = ${archiveMd5}
 
 pkgname = kscript
 


### PR DESCRIPTION
As [mentioned on AUR][1], the latest release there is broken. This was due to the PKGBUILD generation not retaining the variables, but rather attempting to resolve them at release script execution time. Here's a before/after of what's generated:

**Before:**

```
# Maintainer: Holger Brandl https://github.com/holgerbrandl/kscript/

pkgname=kscript
pkgver=2.9.0
pkgrel=1
pkgdesc='Enhanced scripting support for Kotlin on *nix-based systems'
arch=('any')
url='https://github.com/holgerbrandl/kscript'
license=('MIT')
depends=('kotlin')
source=("-.bin.zip::https://github.com/holgerbrandl//releases/download/v/--bin.zip")
sha256sums=('3d62b0db226566506a2531d765547595867230cd5d44dbedc65301cadfecdaaf')

package() {
    cd "/-/bin"

    install -Dm 755 kscript "/usr/bin/kscript"
    install -Dm 644 kscript.jar "/usr/bin/kscript.jar"
}

```

**After:**

```
# Maintainer: Holger Brandl https://github.com/holgerbrandl/kscript/

pkgname=kscript
pkgver=2.9.0
pkgrel=1
pkgdesc='Enhanced scripting support for Kotlin on *nix-based systems'
arch=('any')
url='https://github.com/holgerbrandl/kscript'
license=('MIT')
depends=('kotlin')
source=("${pkgname}-${pkgver}.bin.zip::https://github.com/holgerbrandl/${pkgname}/releases/download/v${pkgver}/${pkgname}-${pkgver}-bin.zip")
sha256sums=('3d62b0db226566506a2531d765547595867230cd5d44dbedc65301cadfecdaaf')

package() {
    cd "${srcdir}/${pkgname}-${pkgver}/bin"

    install -Dm 755 kscript "${pkgdir}/usr/bin/kscript"
    install -Dm 644 kscript.jar "${pkgdir}/usr/bin/kscript.jar"
}

```

Notice that I've also cleaned up the .SRCINFO creation, which wasn't necessarily broken, but had some strange indents.

[1]: https://aur.archlinux.org/packages/kscript/#comment-720593