### PR TITLE
Add missing inputs to the incremental task "test"

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,3 +52,7 @@ val jar by tasks.getting {
 val assemble by tasks.getting {
     dependsOn(shadowJar)
 }
+
+val test by tasks.getting {
+    inputs.dir("${project.projectDir}/test/resources")
+}


### PR DESCRIPTION
Hi

This pull request fixes the incremental task `test`.

This task depends on some test resources included in the `test/resources` directory.
However, this directory is not declared as input to this task, so tests are not executed whenever there are updates to any of those dependent files.

This commit fixes this issue by declaring `test/resources` as input of task `test`.