### PR TITLE
Add option to launch temp intellij as custom command through env property

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ This will open [IntelliJ IDEA](https://www.jetbrains.com/idea/) with a minimalis
 
 ![](misc/readme_images/minus_idea.png)
 
-This assumes that you have the Intellij IDEA command line launcher `idea` in your `PATH`. It can be created in IntelliJ under `Tools -> Create Command-line Launcher`
+This assumes that you have the Intellij IDEA command line launcher `idea` in your `PATH`. It can be created in IntelliJ under `Tools -> Create Command-line Launcher` or  you can set the command used to launch your intellij as `KSCRIPT_IDEA_COMMAND` env property
 
 Deploy scripts as standalone binaries
 --------------------------------------

--- a/src/main/kotlin/kscript/app/AppHelpers.kt
+++ b/src/main/kotlin/kscript/app/AppHelpers.kt
@@ -206,7 +206,8 @@ fun launchIdeaWithKscriptlet(scriptFile: File,
                              customRepos: List<MavenRepo>,
                              includeURLs: List<URL>,
                              compilerOpts: String): String {
-    requireInPath("idea", "Could not find 'idea' in your PATH. It can be created in IntelliJ under `Tools -> Create Command-line Launcher`")
+    val intellijCommand = System.getenv("KSCRIPT_IDEA_COMMAND") ?: "idea"
+    requireInPath("$intellijCommand", "Could not find '$intellijCommand' in your PATH. You must set the command used to launch your intellij as 'KSCRIPT_IDEA_COMMAND' env property")
 
     infoMsg("Setting up idea project from ${scriptFile}")
 
@@ -344,7 +345,7 @@ $kotlinOptions
     val projectPath = tmpProjectDir.absolutePath
     infoMsg("Project set up at $projectPath")
 
-    return "idea \"$projectPath\""
+    return "$intellijCommand \"$projectPath\""
 }
 
 private fun URL.fileName() = this.toURI().path.split("/").last()


### PR DESCRIPTION
## Why
Depending on how your intellij was installed it has not the same command set to launch, so this PR allows to tell kscript what command needs to be considered

## What
Allow the possibility to customize kscript to set your intellij launch command