### PR TITLE
bump kotlin version to 1.3.72

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 plugins {
-    kotlin("jvm") version "1.2.70"
+    kotlin("jvm") version "1.3.72"
     id("com.github.johnrengelman.shadow") version "2.0.4"
 }
 


### PR DESCRIPTION
No specific reason other than not having to download too many kotlin versions.