### PR TITLE
Use hard links for idea project 

### DIFF
--- a/src/main/kotlin/kscript/app/AppHelpers.kt
+++ b/src/main/kotlin/kscript/app/AppHelpers.kt
@@ -327,7 +327,7 @@ $kotlinOptions
         mkdir()
 
         // https://stackoverflow.com/questions/17926459/creating-a-symbolic-link-with-java
-        createSymLink(File(this, scriptFile.name), scriptFile)
+        createLink(File(this, scriptFile.name), scriptFile)
         val scriptDir = Paths.get(scriptFile.path).parent
 
         // also symlink all includes
@@ -346,7 +346,7 @@ $kotlinOptions
                             Pair(this, fetchFromURL(it.toString()))
                         }
                     }
-                    createSymLink(File(symlinkSrcDirAndDestination.first, it.fileName()), symlinkSrcDirAndDestination.second)
+                    createLink(File(symlinkSrcDirAndDestination.first, it.fileName()), symlinkSrcDirAndDestination.second)
                 }
     }
 
@@ -358,11 +358,11 @@ $kotlinOptions
 
 private fun URL.fileName() = this.toURI().path.split("/").last()
 
-private fun createSymLink(link: File, target: File) {
+private fun createLink(link: File, target: File) {
     try {
-        Files.createSymbolicLink(link.toPath(), target.absoluteFile.toPath())
+        Files.createLink(link.toPath(), target.absoluteFile.toPath())
     } catch (e: IOException) {
-        errorMsg("Failed to create symbolic link to script. Copying instead...")
+        errorMsg("Failed to create link to script. Copying instead...")
         target.copyTo(link)
     }
 }


### PR DESCRIPTION
### Use hard links for idea project as Kotlin compiler has issues with symlinks.

The second run of `./gradlew assemble` in generated idea project after a code change always let to

```
> Task :compileKotlin
e: <.kt file path in idea project>: Redeclaration: ClassA
e: <.kt file path in original location>: Redeclaration: ClassA
```
This can only be fixed by cleaning the project or deleting the `build` folder. Which is really annoying when working on a project.

This can be avoided using hard links, plus I see no downside of using hard links here as they would only come to affect if it would be common to copy/replace a different file with the same name over the original project files as a regular use case, which it isn't.

