### PR TITLE
Fix bootstrap script env variable issue

### DIFF
--- a/misc/boostrap_header.sh
+++ b/misc/boostrap_header.sh
@@ -2,7 +2,7 @@ function _in_path() { command -v "$1" >/dev/null 2>&1; }
 _in_path kscript && echo "kscript is already installed at $(which kscript)" 1>&2 || {
     function echo_and_eval() { echo "$ $@" 1>&2; eval "$@" 1>&2; }
     _in_path sdk || {
-        curl "https://get.sdkman.io" | bash 1>&2 && \
+        export SDKMAN_DIR="$HOME/.sdkman" && curl "https://get.sdkman.io" | bash 1>&2 && \
             echo_and_eval source "$SDKMAN_DIR/bin/sdkman-init.sh"
     }
 


### PR DESCRIPTION
### Issue
Error messages in: #270

In `misc/boostrap_header.sh`, it installs SDKMAN using
```bash
curl "https://get.sdkman.io" | bash 1>&2 && \
            echo_and_eval source "$SDKMAN_DIR/bin/sdkman-init.sh"
```
After that, it installs Java, Kotlin, Grade, and Kscript. 
It uses `$SDKMAN_DIR`, but it can't be retrieved from the previous sdkman installation script. so it causes the issue: `misc/boostrap_header.sh` runs `/bin/sdkman-init.sh` since `$SDKMAN_DIR` is not set. In the meantime, the rest of the installation will be failed.


### Fix
I added the declaration of the `SDKMAN_DIR` before SDKMAN installation script runs. The value is same as the one SDKMAN script uses.
There are 2 reasons I declare it explicitly:
* The SDKMAN installation script will use it as the SDKMAN's location. So whatever the default location is changed or not in SDKMAN side, we will always install SDKMAN to `$HOME/.sdkman`
* The rest of the installation will be able to consume this `SDKMAN_DIR` immediately.