### PR TITLE
Add support for Proguard when packaging scripts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 group = "com.github.holgerbrandl.kscript.launcher"
 
 dependencies {
-    compileOnly("org.jetbrains.kotlin:kotlin-stdlib")
+    compile("org.jetbrains.kotlin:kotlin-stdlib")
 
     compile("com.offbytwo:docopt:0.6.0.20150202")
 

--- a/src/main/kotlin/kscript/app/Script.kt
+++ b/src/main/kotlin/kscript/app/Script.kt
@@ -69,8 +69,7 @@ data class Script(val lines: List<String>, val extension: String = "kts") : Iter
     }
 }
 
-
-private val KSCRIPT_DIRECTIVE_ANNO: List<Regex> = listOf("DependsOn", "KotlinOpts", "Include", "EntryPoint", "MavenRepository", "DependsOnMaven", "CompilerOpts")
+private val KSCRIPT_DIRECTIVE_ANNO: List<Regex> = listOf("DependsOn", "KotlinOpts", "Include", "EntryPoint", "MavenRepository", "DependsOnMaven", "CompilerOpts" , "ProguardConfig")
     .map { "^@file:$it[(]".toRegex() }
 
 private fun isKscriptAnnotation(line: String) =
@@ -129,7 +128,7 @@ fun Script.collectDependencies(): List<String> {
 
     // if annotations are used add dependency on kscript-annotations
     if (lines.any { isKscriptAnnotation(it) }) {
-        dependencies += "com.github.holgerbrandl:kscript-annotations:1.4"
+        dependencies += "com.github.holgerbrandl:kscript-annotations:1.5"
     }
 
     return dependencies.distinct()
@@ -210,6 +209,16 @@ fun Script.collectRepos(): List<MavenRepo> {
         }
 }
 
+fun Script.collectProguardConfig(): List<String> {
+
+    // Supports parsing Proguard config configured like this:
+    //
+    // @file:ProguardConfig("-keepclassmembers class CliArgs { *;}")
+
+    val proguardConfigRegex = "(?<!\\/\\/)@file:ProguardConfig\\(\\\"(.*?)\\\"\\)\$".toRegex(RegexOption.MULTILINE)
+
+    return proguardConfigRegex.findAll(lines.joinToString(separator = "\n")).map { it.groupValues[1] }.toList()
+}
 
 //
 // Runtime Configuration


### PR DESCRIPTION
- Use `shadow` to package "fat" jar when using Proguard.
- Allow scripts to add specific Proguard configurations via annotations.

Requires: https://github.com/holgerbrandl/kscript-annotations/pull/4

This is missing tests and I put this up as a "balloon" to see if you are interested in this.

We are seeing packaged scripts becoming really big quickly (we have scripts that package to over 20mb binaries) and with running Proguard we can reduce that size significantly. 

e.g. we were able to "shrink" one of our packaged scripts from ~8MB executable size to under 3MB executable size without even spending time on writing a better config.