### PR TITLE
Fix error with kotlinc-jvm 1.4.10 (JRE 1.8.0_265-b01)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,9 +136,11 @@ To use `kscript` as interpreter for a script just point to it in the shebang lin
 ```kotlin
 #!/usr/bin/env kscript
 
-println("Hello from Kotlin!")
-for (arg in args) {
-    println("arg: $arg")
+fun main(args: Array<String>) {
+    println("Hello from Kotlin!")
+    for (arg in args) {
+        println("arg: $arg")
+    }
 }
 ```
 


### PR DESCRIPTION
For me the example code failed:
```
$ kkotlinc -version 
info: kotlinc-jvm 1.4.10 (JRE 1.8.0_265-b01)
$ ./example.kt            
[kscript] [ERROR] compilation of './example.kt' failed
example.kt:3:1: error: expecting a top level declaration
println("Hello from Kotlin!")
^
example.kt:3:8: error: expecting a top level declaration
println("Hello from Kotlin!")
       ^
example.kt:3:9: error: expecting a top level declaration
println("Hello from Kotlin!")
        ^
example.kt:3:10: error: expecting a top level declaration
println("Hello from Kotlin!")
         ^
example.kt:3:28: error: expecting a top level declaration
println("Hello from Kotlin!")
                           ^
example.kt:3:29: error: expecting a top level declaration
println("Hello from Kotlin!")
                            ^
example.kt:4:1: error: expecting a top level declaration
for (arg in args) {
^
example.kt:4:5: error: expecting a top level declaration
for (arg in args) {
    ^
example.kt:4:6: error: expecting a top level declaration
for (arg in args) {
     ^
example.kt:4:13: error: expecting a top level declaration
for (arg in args) {
            ^
example.kt:4:17: error: expecting a top level declaration
for (arg in args) {
                ^
example.kt:4:19: error: expecting a top level declaration
for (arg in args) {
                  ^
example.kt:4:19: error: function declaration must have a name
for (arg in args) {
                  ^
example.kt:5:20: error: unresolved reference: arg
    println("arg: $arg")
                   ^

```

What fixed it for me was to wrap the code in a `main()` function.

Sweet script launcher, by the way! Very happy this exists.
