### PR TITLE
Fix Java info in `kscript --version`

### DIFF
--- a/src/main/kotlin/kscript/app/Kscript.kt
+++ b/src/main/kotlin/kscript/app/Kscript.kt
@@ -79,7 +79,7 @@ fun main(args: Array<String>) {
         versionCheck()
         val systemInfo = evalBash("kotlin -version").stdout
         info("Kotlin    : " + systemInfo.split('(')[0].removePrefix("Kotlin version").trim())
-        info("Java      : " + systemInfo.split('(')[1].split('-')[0].trim())
+        info("Java      : " + systemInfo.split('(')[1].split('-', ')')[0].trim())
         quit(0)
     }
 


### PR DESCRIPTION
When `kotlin -java` contains Java version output like so:

```
Kotlin version 1.4.20-release-308 (JRE 15.0.1+9)
```

then `kscript --version` shows

```
Java      : JRE 15.0.1+9)
```

Note the last character, a closing parenthesis that shouldn't be there.
This commit fixes that issue.