### PR TITLE
Support for running bash commands on Windows (via sh instead of bash)

### DIFF
--- a/src/main/kotlin/kscript/app/AppHelpers.kt
+++ b/src/main/kotlin/kscript/app/AppHelpers.kt
@@ -23,8 +23,10 @@ data class ProcessResult(val command: String, val exitCode: Int, val stdout: Str
 fun evalBash(cmd: String, wd: File? = null,
              stdoutConsumer: Consumer<String> = StringBuilderConsumer(),
              stderrConsumer: Consumer<String> = StringBuilderConsumer()): ProcessResult {
-    return runProcess("bash", "-c", cmd,
-        wd = wd, stderrConsumer = stderrConsumer, stdoutConsumer = stdoutConsumer)
+    return runProcess(
+        *getBashCommandsForCurrentOS(), cmd,
+        wd = wd, stderrConsumer = stderrConsumer, stdoutConsumer = stdoutConsumer
+    )
 }
 
 

--- a/src/main/kotlin/kscript/app/OSHelpers.kt
+++ b/src/main/kotlin/kscript/app/OSHelpers.kt
@@ -1,0 +1,25 @@
+package kscript.app
+
+enum class OS {
+    WINDOWS, UNIX
+}
+
+fun getOS(): OS {
+    val os = System.getProperty("os.name").toLowerCase()
+    return when {
+        os.contains("win") -> {
+            OS.WINDOWS
+        }
+        os.contains("nix") || os.contains("nux") || os.contains("aix") ||  os.contains("mac") -> {
+            OS.UNIX
+        }
+        else -> OS.UNIX
+    }
+}
+
+val CURRENT_OS = getOS()
+
+fun getBashCommandsForCurrentOS() = when(CURRENT_OS){
+    OS.WINDOWS -> arrayOf("sh", "-c")
+    OS.UNIX -> arrayOf("bash", "-c")
+}


### PR DESCRIPTION
Kotlin was in my PATH, bu I was getting error `[kscript] [ERROR] kotlinc is not in PATH`. So I've made some investigation and testing. As I figured out problem was with `bash -c` command. For some reason it's not showing any output neither while running on my windows cmd nor from kscript. There wasn't any output even from simple `echo`. Fortunately I found that command `sh -c` is working perfectly.
For that reason I wrote some piece of code which is choosing proper bash command for OS.
However I'm not sure if problem is only in my enviroment (with git-bash instalation or some windows configuration?) or global for windows.