### PR TITLE
Add native bundled runtime option

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,12 +39,12 @@ jobs:
       - name: Install kotlin
         run: |
           source "/home/runner/.sdkman/bin/sdkman-init.sh"
-          sdk install kotlin 1.4.31
+          sdk install kotlin 1.6.0
 
       - name: Install gradle
         run: |
           source "/home/runner/.sdkman/bin/sdkman-init.sh"
-          sdk install gradle 6.7
+          sdk install gradle 7.2
 
 
       # https://stackoverflow.com/questions/50104666/gradle-difference-between-test-and-check

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,8 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 plugins {
-    kotlin("jvm") version "1.4.32"
-    id("com.github.johnrengelman.shadow") version "5.2.0"
+    kotlin("jvm") version "1.6.0"
+    id("com.github.johnrengelman.shadow") version "7.0.0"
 }
 
 repositories {
@@ -12,18 +12,19 @@ repositories {
 group = "com.github.holgerbrandl.kscript.launcher"
 
 //val kotlinVersion: String by rootProject.extra
-val kotlinVersion: String ="1.4.32"
+val kotlinVersion: String ="1.6.0"
 
 dependencies {
-    compile("com.offbytwo:docopt:0.6.0.20150202")
+    implementation("com.offbytwo:docopt:0.6.0.20150202")
 
     implementation("org.jetbrains.kotlin:kotlin-scripting-common:$kotlinVersion")
     implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
     implementation("org.jetbrains.kotlin:kotlin-scripting-jvm:$kotlinVersion")
     implementation("org.jetbrains.kotlin:kotlin-scripting-dependencies:$kotlinVersion")
     implementation("org.jetbrains.kotlin:kotlin-scripting-dependencies-maven:$kotlinVersion")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.0-RC")
 
-    compile("org.slf4j:slf4j-nop:1.7.30")
+    implementation("org.slf4j:slf4j-nop:1.7.30")
 
     testImplementation("junit:junit:4.12")
     testImplementation( "io.kotlintest:kotlintest:2.0.7")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/kscript/app/DependencyUtil.kt
+++ b/src/main/kotlin/kscript/app/DependencyUtil.kt
@@ -1,7 +1,6 @@
 package kscript.app
 
 import kotlinx.coroutines.runBlocking
-import org.eclipse.aether.artifact.DefaultArtifact
 import java.io.File
 import kotlin.script.experimental.api.valueOrThrow
 import kotlin.script.experimental.dependencies.CompoundDependenciesResolver

--- a/src/main/kotlin/kscript/app/Package.kt
+++ b/src/main/kotlin/kscript/app/Package.kt
@@ -127,13 +127,13 @@ class KScriptPackager(
             }
             
             dependencies {
-                compile "org.jetbrains.kotlin:kotlin-stdlib"
+                implementation "org.jetbrains.kotlin:kotlin-stdlib"
                 ${dependencies.joinToString("\n    ") { "implementation \"$it\"" }}
             
-                compile group: 'org.jetbrains.kotlin', name: 'kotlin-script-runtime', version: '${KotlinVersion.CURRENT}'
+                implementation group: 'org.jetbrains.kotlin', name: 'kotlin-script-runtime', version: '${KotlinVersion.CURRENT}'
             
                 // https://stackoverflow.com/questions/20700053/how-to-add-local-jar-file-dependency-to-build-gradle-file
-                compile files('${scriptJar.invariantSeparatorsPath}')
+                implementation files('${scriptJar.invariantSeparatorsPath}')
             }
             
             application {

--- a/src/main/kotlin/kscript/app/Package.kt
+++ b/src/main/kotlin/kscript/app/Package.kt
@@ -1,0 +1,149 @@
+package kscript.app
+
+import java.io.File
+import java.nio.file.Paths
+
+class KScriptPackager(
+    val scriptJar : File,
+    val wrapperClassName : String,
+    val dependencies : List<String>,
+    val customRepos: List<MavenRepo>,
+    val runtimeOptions: List<String>,
+    val appName: String
+) {
+    val timestamp = System.currentTimeMillis()
+    /**
+     * Create and use a temporary gradle project to package the compiled script
+     */
+    fun makeExecutableJar() {
+        val fatJar = packageAndExtract(
+            taskName = "shadowJar",
+            gradleScript = packagingGradleScript(
+                pluginRequire = """id "com.github.johnrengelman.shadow" version "7.0.0"""",
+                pluginConfigure = """
+                    shadowJar {
+                       archiveBaseName.set('shadow')
+                       archiveClassifier.set('')
+                       archiveVersion.set('')
+                    }
+                """.trimIndent()
+            )
+        ).resolve("build/libs/shadow.jar")
+        val resultFile = File(Paths.get("").toAbsolutePath().toFile(), appName).absoluteFile
+        resultFile.outputStream().use { fos ->
+            fos.write("#!/usr/bin/java ${runtimeOptions.joinToString(" ")} -jar\n".toByteArray())
+            fatJar.inputStream().use { fis ->
+                fis.copyTo(fos)
+            }
+        }
+        resultFile.setExecutable(true)
+        infoMsg("Finished packaging into $resultFile")
+    }
+
+    fun makeSelfExtractingRuntime() {
+        errorIf(getJavaVersion() < 11) { "A runtime of Java 11 or greater is required to create a self-extracting runtime." }
+        val tarzip = packageAndExtract(
+            taskName = "tarzipImage",
+            gradleScript = packagingGradleScript(
+                pluginRequire = """id "org.beryx.runtime" version "1.12.7"""",
+                pluginConfigure = """
+                    runtime {
+                        options = ['--strip-debug', '--compress', '2', '--no-header-files', '--no-man-pages']
+                    }
+                    
+            
+                    task tarzipImage(type: Tar, dependsOn: tasks.getByName("runtime")){
+                        archiveFileName = "temparchive.tar.gz"
+                        destinationDirectory = file("${"$"}buildDir/bundled")
+                        compression = Compression.GZIP
+                        from file("${"$"}buildDir/image/")
+                    }
+                """.trimIndent()
+            ),
+        ).resolve("build/bundled/temparchive.tar.gz")
+
+        val scriptTempFolder = "/tmp/$appName-$timestamp"
+        val resultFile = File(Paths.get("").toAbsolutePath().toFile(), appName).absoluteFile
+        resultFile.outputStream().use { fos ->
+            fos.write("""
+                #!/bin/sh
+                if [ ! -d "$scriptTempFolder" ]; then
+                    mkdir "$scriptTempFolder"
+                    sed -e '1,/^#EOF#${'$'}/d' "${'$'}0" | tar -C "$scriptTempFolder" -kzxf -
+                fi
+                cd $scriptTempFolder
+                exec "./bin/$appName" "$@"
+                exit
+                #EOF#
+            """.trimIndent().toByteArray())
+            fos.write("\n".toByteArray())
+            tarzip.inputStream().use { fis ->
+                fis.copyTo(fos)
+            }
+        }
+        resultFile.setExecutable(true)
+        infoMsg("Finished packaging into $resultFile")
+    }
+
+    private fun packageAndExtract(
+        taskName : String,
+        gradleScript : String,
+    ) : File {
+        ShellUtils.requireInPath("gradle", "gradle is required to package kscripts")
+        infoMsg("Packaging script '$appName' into standalone executable...")
+
+        val tempProjectDirectory = KSCRIPT_CACHE_DIR
+            .run { File(this, "kscript_tmp_project__${scriptJar.name}_${timestamp}") }
+            .apply { mkdir() }
+
+        tempProjectDirectory.resolve("build.gradle").writeText(gradleScript)
+
+        val packageResult = evalBash("cd '${tempProjectDirectory}' && gradle $taskName")
+
+        errorIf(packageResult.exitCode != 0) { "packaging of '$appName' failed:\n$packageResult" }
+
+        return tempProjectDirectory
+    }
+
+
+    /**
+     * Generates a gradle script for packaging.
+     * Note that this is templated differently for shadow jar vs bundled runtime instead of one script containing both
+     * because of interaction effects between the shadow and badass-runtime plugin.
+     */
+    private fun packagingGradleScript(pluginRequire : String, pluginConfigure : String) : String {
+        // https://shekhargulati.com/2015/09/10/gradle-tip-using-gradle-plugin-from-local-maven-repository/
+        return """
+            plugins {
+                id "org.jetbrains.kotlin.jvm" version "${KotlinVersion.CURRENT}"
+                id 'application'
+                $pluginRequire
+            }
+            
+            repositories {
+                mavenLocal()
+                mavenCentral()
+                ${customRepos.joinToString("\n    ") { "maven { url '${it.url}'}" }}
+            }
+            
+            dependencies {
+                compile "org.jetbrains.kotlin:kotlin-stdlib"
+                ${dependencies.joinToString("\n    ") { "implementation \"$it\"" }}
+            
+                compile group: 'org.jetbrains.kotlin', name: 'kotlin-script-runtime', version: '${KotlinVersion.CURRENT}'
+            
+                // https://stackoverflow.com/questions/20700053/how-to-add-local-jar-file-dependency-to-build-gradle-file
+                compile files('${scriptJar.invariantSeparatorsPath}')
+            }
+            
+            application {
+                mainClass = '$wrapperClassName'
+                applicationName = '$appName'
+                applicationDefaultJvmArgs =[${runtimeOptions.joinToString(", "){"'$it'"}}]
+            }
+            
+            $pluginConfigure
+        """.trimIndent()
+    }
+}
+

--- a/src/main/kotlin/kscript/app/Package.kt
+++ b/src/main/kotlin/kscript/app/Package.kt
@@ -31,7 +31,7 @@ class KScriptPackager(
         ).resolve("build/libs/shadow.jar")
         val resultFile = File(Paths.get("").toAbsolutePath().toFile(), appName).absoluteFile
         resultFile.outputStream().use { fos ->
-            fos.write("#!/usr/bin/java ${runtimeOptions.joinToString(" ")} -jar\n".toByteArray())
+            fos.write("#!/usr/bin/env -S java ${runtimeOptions.joinToString(" ")} -jar\n".toByteArray())
             fatJar.inputStream().use { fis ->
                 fis.copyTo(fos)
             }
@@ -71,8 +71,7 @@ class KScriptPackager(
                     mkdir "$scriptTempFolder"
                     sed -e '1,/^#EOF#${'$'}/d' "${'$'}0" | tar -C "$scriptTempFolder" -kzxf -
                 fi
-                cd $scriptTempFolder
-                exec "./bin/$appName" "$@"
+                exec "$scriptTempFolder/bin/$appName" "$@"
                 exit
                 #EOF#
             """.trimIndent().toByteArray())


### PR DESCRIPTION
So this PR is more of a proof of concept than anything immediately production-ready, but the gist is that I wanted to try using the [Badass Runtime plugin](https://badass-runtime-plugin.beryx.org/releases/latest/) to generate truly self-contained scriptlet executables. Basically, this bundles a stripped-down JRE runtime into a self-extracting shell script. Inefficient ("Hello World" is 20 MB) but potentially very useful for using KScript in situations without known JRE deployment. I'm not really sure of a good name to distinguish this from the existing fat jar packaging yet, but went with the "--native" flag for the moment.

Also since the Capsule project has been dead for a long while now (and seems to have Java 9+ issues), I tried replacing it with the shadow plugin. I admit I don't really understand the differences between the two (since the Capsule docsite is dead) but they appear to do the same thing, more or less?

Let me know if you're interested or foresee difficulties, and I could put some more effort into this PR. Currently it basically works (on Linux) with the simple tests I've run so far.