### PR TITLE
Fix for OsType comparison logic

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,7 +16,9 @@ Major Enhancements
 
 Minor Enhancements
 
-## 4.0.0
+## 4.0.2
+
+Released 2022-05-18
 
 Rewrite by https://github.com/aartiPl
 

--- a/src/main/kotlin/kscript/app/model/OsType.kt
+++ b/src/main/kotlin/kscript/app/model/OsType.kt
@@ -9,6 +9,6 @@ enum class OsType(val osName: String) {
 
     companion object {
         fun findOrThrow(name: String) =
-            values().find { it.osName.equals(name, true) } ?: throw IllegalArgumentException("Unsupported OS: $name")
+            values().find { name.contains(it.osName, true) } ?: throw IllegalArgumentException("Unsupported OS: $name")
     }
 }


### PR DESCRIPTION
Changed equals to contains so run for os 'darwin21' also works