### PR TITLE
Pass OSTYPE in environment rather than command-line argument.

### DIFF
--- a/src/kscript
+++ b/src/kscript
@@ -46,4 +46,5 @@ fi
 export KSCRIPT_FILE="$1"
 
 ## run it using command substitution to have just the user process once kscript is done
-eval "exec $("${KOTLIN_BIN}kotlin" -classpath "${JAR_PATH}" kscript.app.KscriptKt "$OSTYPE" "$@")"
+export OSTYPE="$OSTYPE"
+eval "exec $("${KOTLIN_BIN}kotlin" -classpath "${JAR_PATH}" kscript.app.KscriptKt "$@")"

--- a/src/kscript.bat
+++ b/src/kscript.bat
@@ -4,5 +4,6 @@ for /f %%i in ('where kscript.bat') do set ABS_KSCRIPT_PATH=%%i
 set JAR_PATH=%ABS_KSCRIPT_PATH:~0,-4%.jar
 
 rem kotlin -classpath %JAR_PATH% kscript.app.KscriptKt "windows" %*
-FOR /F "tokens=* USEBACKQ" %%O IN (`kotlin -classpath %JAR_PATH% kscript.app.KscriptKt "windows" %*`) DO (SET RESULT=%%O)
+set OSTYPE=windows
+FOR /F "tokens=* USEBACKQ" %%O IN (`kotlin -classpath %JAR_PATH% kscript.app.KscriptKt  %*`) DO (SET RESULT=%%O)
 %RESULT%

--- a/src/main/kotlin/kscript/app/Kscript.kt
+++ b/src/main/kotlin/kscript/app/Kscript.kt
@@ -22,8 +22,8 @@ const val KSCRIPT_VERSION = "4.0.4"
 
 fun main(args: Array<String>) {
     try {
-        val config = Config.builder().apply { osType = args[0] }.build()
-        val remainingArgs = args.drop(1)
+        val config = Config.builder().apply { osType = System.getenv("OSTYPE") }.build()
+        val remainingArgs = args
 
         // skip org.docopt for version and help to allow for lazy version-check
         val usage = Templates.usageOptions(config.selfName, KSCRIPT_VERSION)

--- a/src/main/kotlin/kscript/app/code/Templates.kt
+++ b/src/main/kotlin/kscript/app/code/Templates.kt
@@ -8,13 +8,13 @@ object Templates {
     @Language("sh")
     val bootstrapHeader = """
         #!/bin/bash
-        
+
         //usr/bin/env echo '
         /**** BOOTSTRAP kscript ****\'>/dev/null
         command -v kscript >/dev/null 2>&1 || source /dev/stdin <<< "${'$'}(curl -L https://git.io/fpF1K)"
         exec kscript $0 "$@"
         \*** IMPORTANT: Any code including imports and annotations must come after this line ***/
-        
+
         """.trimIndent()
 
     val textProcessingPreamble = """
@@ -22,7 +22,7 @@ object Templates {
 
         import kscript.text.*
         val lines = resolveArgFile(args)
-        
+
         """.trimIndent()
 
     val executeHeader = """
@@ -68,7 +68,7 @@ object Templates {
             </configuration>
             """.trimIndent()
         } else {
-            """  
+            """
         <configuration default="false" name="Main" type="BashConfigurationType" factoryName="Bash">
             <option name="INTERPRETER_OPTIONS" value="" />
             <option name="INTERPRETER_PATH" value="kscript" />
@@ -115,5 +115,6 @@ object Templates {
         License   : MIT
         Version   : v${version}
         Website   : https://github.com/holgerbrandl/kscript
+        OS type   : ${System.getenv("OSTYPE")}
         """.trimIndent().trim()
 }


### PR DESCRIPTION
This approach appears to work fine in Bash on Ubuntu, macOS, Cygwin and MSYS2. I haven't tested on Windows (other than Cygwin/MSYS2), but I wouldn't expect any problems.