### PR TITLE
Option to list dependencies

### DIFF
--- a/src/main/kotlin/io/github/kscripting/kscript/KscriptHandler.kt
+++ b/src/main/kotlin/io/github/kscripting/kscript/KscriptHandler.kt
@@ -78,6 +78,12 @@ class KscriptHandler(
             DependencyResolver(script.repositories).resolve(script.dependencies) + localArtifacts
         }
 
+        if (options.containsKey("dependencies")) {
+            info("Dependencies:")
+            info(resolvedDependencies.joinToString("\n"))
+            return
+        }
+
         //  Create temporary dev environment
         if (options.containsKey("idea")) {
             val path = cache.getOrCreateIdeaProject(script.digest) { basePath ->

--- a/src/main/kotlin/io/github/kscripting/kscript/util/OptionsUtils.kt
+++ b/src/main/kotlin/io/github/kscripting/kscript/util/OptionsUtils.kt
@@ -23,6 +23,7 @@ object OptionsUtils {
             .addOption("h", "help", false, "Prints help information")
             .addOption("v", "version", false, "Prints version information")
             .addOption("c", "clear-cache", false, "Wipes out cached script jars and urls")
+            .addOption("n", "dependencies", false, "Prints list of dependencies")
     }
 
     fun createHelpText(selfName: String, options: Options): String {


### PR DESCRIPTION
For better integration with other development environments, the option to list dependencies is added, and thus detect them directly.

An example of use would be to create a kls-classpath file with which the kotlin-language-server can detect dependencies.

https://github.com/fwcd/kotlin-language-server/tree/main?tab=readme-ov-file#figuring-out-the-dependencies